### PR TITLE
Review Service: validate Review entities before persisting

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,11 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:review-service:shop.microservices.core.review.PersistenceTests",
+      "microservices:review-service:shop.microservices.core.review.ReviewServiceApiTests",
+      "microservices:review-service:shop.microservices.core.review.ReviewValidationTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/microservices/review-service/build.gradle
+++ b/microservices/review-service/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation project(':util')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation:3.5.3'
     implementation 'com.mysql:mysql-connector-j'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/microservices/review-service/src/main/java/shop/microservices/core/review/persistence/ReviewEntity.java
+++ b/microservices/review-service/src/main/java/shop/microservices/core/review/persistence/ReviewEntity.java
@@ -1,6 +1,9 @@
 package shop.microservices.core.review.persistence;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Entity
 @Table(name = "reviews", indexes = {
@@ -15,10 +18,15 @@ public class ReviewEntity {
     @Version
     private int version;
 
+    @Min(0)
     private int productId;
+    @Min(0)
     private int reviewId;
+    @NotBlank
     private String author;
+    @NotBlank
     private String subject;
+    @Size(min = 50, max = 200)
     private String content;
 
     public ReviewEntity() {

--- a/microservices/review-service/src/main/resources/db/init/init.sql
+++ b/microservices/review-service/src/main/resources/db/init/init.sql
@@ -17,7 +17,7 @@ CREATE TABLE reviews
     review_id  INT NOT NULL,
     author     VARCHAR(255),
     subject    VARCHAR(255),
-    content    TEXT,
+    content    VARCHAR(200),
     PRIMARY KEY (id),
     UNIQUE INDEX reviews_unique_idx (product_id, review_id)
 );

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/PersistenceTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/PersistenceTests.java
@@ -25,6 +25,8 @@ import static org.springframework.transaction.annotation.Propagation.NOT_SUPPORT
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class PersistenceTests extends MySqlTestBase {
 
+    private static final String REVIEW_CONTENT = "Lorem ipsum dolor sit amet, consetetur sadipscingw";
+
     @Autowired
     private ReviewRepository repository;
 
@@ -34,7 +36,7 @@ class PersistenceTests extends MySqlTestBase {
     void setupDb() {
         repository.deleteAll();
 
-        ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", "c");
+        ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", REVIEW_CONTENT);
         savedEntity = repository.save(entity);
 
         assertEqualsReview(entity, savedEntity);
@@ -42,7 +44,7 @@ class PersistenceTests extends MySqlTestBase {
 
     @Test
     void create() {
-        ReviewEntity newEntity = new ReviewEntity(1, 3, "a", "s", "c");
+        ReviewEntity newEntity = new ReviewEntity(1, 3, "a", "s", REVIEW_CONTENT);
         repository.save(newEntity);
 
         ReviewEntity foundEntity = repository.findById(newEntity.getId()).get();
@@ -78,7 +80,7 @@ class PersistenceTests extends MySqlTestBase {
     @Test
     void duplicateError() {
         assertThrows(DataIntegrityViolationException.class, () -> {
-            ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", "c");
+            ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", REVIEW_CONTENT);
             repository.save(entity);
         });
     }

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApiTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApiTests.java
@@ -21,6 +21,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class ReviewServiceApiTests extends MySqlTestBase {
 
+    private static final String REVIEW_CONTENT = "Lorem ipsum dolor sit amet, consetetur sadipscingw";
+
     @Autowired
     private MockMvcTester mockMvcTester;
 
@@ -125,7 +127,7 @@ class ReviewServiceApiTests extends MySqlTestBase {
     }
 
     private AbstractJsonContentAssert<?> postAndVerifyReview(int productId, int reviewId, HttpStatus expectedStatus) {
-        Review review = new Review(productId, reviewId, "Author " + reviewId, "Subject " + reviewId, "Content " + reviewId, "SA");
+        Review review = new Review(productId, reviewId, "Author " + reviewId, "Subject " + reviewId, REVIEW_CONTENT + reviewId, "SA");
         return mockMvcTester.post()
                 .uri("/review")
                 .contentType(APPLICATION_JSON)

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewValidationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewValidationTests.java
@@ -1,0 +1,50 @@
+package shop.microservices.core.review;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+import shop.microservices.core.review.persistence.ReviewEntity;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReviewValidationTests {
+
+    @Test
+    public void testReviewEntityValidationNegative() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = validatorFactory.getValidator();
+
+            var violations = validator.validate(
+                    new ReviewEntity(-1, -1, "", "", "test"));
+
+            assertFalse(violations.isEmpty());
+            assertEquals(5, violations.size());
+            assertThat(violations)
+                    .extracting(it -> it.getPropertyPath() + " " + it.getMessage())
+                    .containsExactlyInAnyOrder(
+                            "productId must be greater than or equal to 0",
+                            "reviewId must be greater than or equal to 0",
+                            "author must not be blank",
+                            "content size must be between 50 and 200",
+                            "subject must not be blank");
+        }
+    }
+
+    @Test
+    public void testReviewEntityValidationPositive() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = validatorFactory.getValidator();
+
+            var violations = validator.validate(
+                    new ReviewEntity(
+                            0,
+                            0,
+                            "John Snow",
+                            "Test",
+                            "Lorem ipsum dolor sit amet, consetetur sadipscingw"));
+
+            assertTrue(violations.isEmpty());
+        }
+    }
+}


### PR DESCRIPTION
We need to ensure that:

- `productId` / `reviewId` >= 0
- `author` / `subject` / `content` are not blank
- `content` is more that 50 characters 