### PR TITLE
Recommendation Service: enable recommendations persisting

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:recommendation-service:shop.microservices.core.recommendation.RecommendationServiceApiTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/api/src/main/java/shop/api/core/recommendation/Recommendation.java
+++ b/api/src/main/java/shop/api/core/recommendation/Recommendation.java
@@ -8,4 +8,7 @@ public record Recommendation(
         String content,
         String serviceAddress
 ) {
+    public Recommendation withServiceAddress(String serviceAddress) {
+        return new Recommendation(productId, recommendationId, author, rate, content, serviceAddress);
+    }
 }

--- a/api/src/main/java/shop/api/core/recommendation/RecommendationService.java
+++ b/api/src/main/java/shop/api/core/recommendation/RecommendationService.java
@@ -1,11 +1,34 @@
 package shop.api.core.recommendation;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 public interface RecommendationService {
+
+    /**
+     * Sample usage, see below.
+     * <p>
+     * curl -X POST $HOST:$PORT/recommendation \
+     * -H "Content-Type: application/json" --data \
+     * '{"productId":123,"recommendationId":456,"author":"me","rate":5,"content":"yada, yada, yada"}'
+     *
+     * @param body A JSON representation of the new recommendation
+     * @return A JSON representation of the newly created recommendation
+     */
+    @PostMapping(
+            value = "/recommendation",
+            consumes = "application/json",
+            produces = "application/json")
+    Recommendation createRecommendation(@RequestBody Recommendation body);
+
+    /**
+     * Sample usage: "curl -X DELETE $HOST:$PORT/recommendation?productId=1".
+     *
+     * @param productId ID of the product
+     */
+    @DeleteMapping(value = "/recommendation")
+    void deleteRecommendations(@RequestParam(value = "productId", required = true) int productId);
 
     /**
      * Sample usage: "curl $HOST:$PORT/recommendation?productId=1".

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
     mem_limit: 512m
     environment:
       - SPRING_PROFILES_ACTIVE=docker
+    depends_on:
+      mongodb:
+        condition: service_healthy
 
   review:
     build: microservices/review-service
@@ -29,6 +32,18 @@ services:
       - "8080:8080"
     environment:
       - SPRING_PROFILES_ACTIVE=docker
+
+  mongodb:
+    image: mongo:6.0.4
+    mem_limit: 512m
+    ports:
+      - "27017:27017"
+    command: mongod
+    healthcheck:
+      test: "mongostat -n 1"
+      interval: 5s
+      timeout: 2s
+      retries: 60
 
   mysql:
     image: mysql:8.0.32

--- a/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeIntegration.java
+++ b/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeIntegration.java
@@ -96,6 +96,17 @@ public class ProductCompositeIntegration implements ProductService, Recommendati
         }
     }
 
+    @Override
+    public Recommendation createRecommendation(Recommendation body) {
+        return restTemplate.postForObject(recommendationServiceUrl, body, Recommendation.class);
+    }
+
+    @Override
+    public void deleteRecommendations(int productId) {
+        String url = recommendationServiceUrl + "?productId=" + productId;
+        restTemplate.delete(url);
+    }
+
     public List<Review> getReviews(int productId) {
         try {
             String url = reviewServiceUrl + productId;

--- a/microservices/recommendation-service/build.gradle
+++ b/microservices/recommendation-service/build.gradle
@@ -23,8 +23,13 @@ dependencies {
     implementation project(':api')
     implementation project(':util')
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.google.code.gson:gson:2.13.1'
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mongodb'
 }
 
 tasks.withType(Test).configureEach {

--- a/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/RecommendationServiceApplication.java
+++ b/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/RecommendationServiceApplication.java
@@ -1,14 +1,48 @@
 package shop.microservices.core.recommendation;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.data.mongodb.core.index.IndexResolver;
+import org.springframework.data.mongodb.core.index.MongoPersistentEntityIndexResolver;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
+import shop.microservices.core.recommendation.persistence.RecommendationEntity;
 
 @SpringBootApplication
 @ComponentScan("shop")
 public class RecommendationServiceApplication {
 
+    private static final Logger LOG = LoggerFactory.getLogger(RecommendationServiceApplication.class);
+
+    private final MongoOperations mongoTemplate;
+
     public static void main(String[] args) {
-        SpringApplication.run(RecommendationServiceApplication.class, args);
+        ConfigurableApplicationContext ctx = SpringApplication.run(RecommendationServiceApplication.class, args);
+
+        String mongoDbHost = ctx.getEnvironment().getProperty("spring.data.mongodb.host");
+        String mongoDbPort = ctx.getEnvironment().getProperty("spring.data.mongodb.port");
+        LOG.info("Connected to MongoDb: {}:{}", mongoDbHost, mongoDbPort);
+    }
+
+    public RecommendationServiceApplication(MongoOperations mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @EventListener(ContextRefreshedEvent.class)
+    public void initIndicesAfterStartup() {
+        MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext = mongoTemplate.getConverter().getMappingContext();
+        IndexResolver resolver = new MongoPersistentEntityIndexResolver(mappingContext);
+
+        IndexOperations indexOps = mongoTemplate.indexOps(RecommendationEntity.class);
+        resolver.resolveIndexFor(RecommendationEntity.class).forEach(indexOps::createIndex);
     }
 }

--- a/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/persistence/RecommendationEntity.java
+++ b/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/persistence/RecommendationEntity.java
@@ -1,0 +1,90 @@
+package shop.microservices.core.recommendation.persistence;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "recommendations")
+@CompoundIndex(name = "prod-rec-id", unique = true, def = "{'productId': 1, 'recommendationId' : 1}")
+public class RecommendationEntity {
+
+    @Id
+    private String id;
+
+    @Version
+    private Integer version;
+
+    private int productId;
+    private int recommendationId;
+    private String author;
+    private int rating;
+    private String content;
+
+    public RecommendationEntity() {
+    }
+
+    public RecommendationEntity(int productId, int recommendationId, String author, int rating, String content) {
+        this.productId = productId;
+        this.recommendationId = recommendationId;
+        this.author = author;
+        this.rating = rating;
+        this.content = content;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    public int getProductId() {
+        return productId;
+    }
+
+    public void setProductId(int productId) {
+        this.productId = productId;
+    }
+
+    public int getRecommendationId() {
+        return recommendationId;
+    }
+
+    public void setRecommendationId(int recommendationId) {
+        this.recommendationId = recommendationId;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public int getRating() {
+        return rating;
+    }
+
+    public void setRating(int rating) {
+        this.rating = rating;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/persistence/RecommendationRepository.java
+++ b/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/persistence/RecommendationRepository.java
@@ -1,0 +1,9 @@
+package shop.microservices.core.recommendation.persistence;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface RecommendationRepository extends CrudRepository<RecommendationEntity, String> {
+    List<RecommendationEntity> findByProductId(int productId);
+}

--- a/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/services/MappingUtils.java
+++ b/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/services/MappingUtils.java
@@ -1,0 +1,37 @@
+package shop.microservices.core.recommendation.services;
+
+import shop.api.core.recommendation.Recommendation;
+import shop.microservices.core.recommendation.persistence.RecommendationEntity;
+
+import java.util.List;
+
+public final class MappingUtils {
+
+    private MappingUtils() {
+    }
+
+    public static RecommendationEntity apiToEntity(Recommendation recommendation) {
+        return new RecommendationEntity(
+                recommendation.productId(),
+                recommendation.recommendationId(),
+                recommendation.author(),
+                recommendation.rate(),
+                recommendation.content());
+    }
+
+    public static Recommendation entityToApi(RecommendationEntity recommendation) {
+        return new Recommendation(
+                recommendation.getProductId(),
+                recommendation.getRecommendationId(),
+                recommendation.getAuthor(),
+                recommendation.getRating(),
+                recommendation.getContent(),
+                null);
+    }
+
+    public static List<Recommendation> entityListToApiList(List<RecommendationEntity> recommendationEntityList) {
+        return recommendationEntityList.stream()
+                .map(MappingUtils::entityToApi)
+                .toList();
+    }
+}

--- a/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/services/RecommendationServiceImpl.java
+++ b/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/services/RecommendationServiceImpl.java
@@ -1,20 +1,59 @@
 package shop.microservices.core.recommendation.services;
 
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.web.bind.annotation.RestController;
 import shop.api.core.recommendation.Recommendation;
 import shop.api.core.recommendation.RecommendationService;
 import shop.api.exceptions.InvalidInputException;
+import shop.microservices.core.recommendation.persistence.RecommendationEntity;
+import shop.microservices.core.recommendation.persistence.RecommendationRepository;
+import shop.util.http.ServiceUtil;
 
 import java.util.List;
+
+import static shop.microservices.core.recommendation.services.MappingUtils.*;
 
 @RestController
 public class RecommendationServiceImpl implements RecommendationService {
 
+    private final RecommendationRepository repository;
+
+    private final ServiceUtil serviceUtil;
+
+    public RecommendationServiceImpl(RecommendationRepository repository, ServiceUtil serviceUtil) {
+        this.repository = repository;
+        this.serviceUtil = serviceUtil;
+    }
+
+    @Override
+    public Recommendation createRecommendation(Recommendation body) {
+        try {
+            RecommendationEntity entity = apiToEntity(body);
+            RecommendationEntity newEntity = repository.save(entity);
+
+            return entityToApi(newEntity);
+
+        } catch (DuplicateKeyException dke) {
+            throw new InvalidInputException("Duplicate key, Product Id: " + body.productId() + ", Recommendation Id:" + body.recommendationId());
+        }
+    }
+
     @Override
     public List<Recommendation> getRecommendations(int productId) {
-        if (productId < 0)
+        if (productId < 0) {
             throw new InvalidInputException("Invalid productId: " + productId);
+        }
 
-        return List.of(new Recommendation(0, 0, "", 0, "", ""));
+        List<RecommendationEntity> entityList = repository.findByProductId(productId);
+
+        return entityListToApiList(entityList)
+                .stream()
+                .map(r -> r.withServiceAddress(serviceUtil.getServiceAddress()))
+                .toList();
+    }
+
+    @Override
+    public void deleteRecommendations(int productId) {
+        repository.deleteAll(repository.findByProductId(productId));
     }
 }

--- a/microservices/recommendation-service/src/main/resources/application.yml
+++ b/microservices/recommendation-service/src/main/resources/application.yml
@@ -1,5 +1,12 @@
 server.port: 7003
+
+spring.data.mongodb:
+  host: localhost
+  port: 27017
+  database: recommendation-db
 ---
 spring.config.activate.on-profile: docker
 
 server.port: 8080
+
+spring.data.mongodb.host: mongodb

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/MongoDbTestBase.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/MongoDbTestBase.java
@@ -1,0 +1,29 @@
+package shop.microservices.core.recommendation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+
+public abstract class MongoDbTestBase {
+
+    private static final MongoDBContainer database = new MongoDBContainer("mongo:6.0.4");
+
+    @BeforeAll
+    public static void startDb() {
+        database.start();
+    }
+
+    @AfterAll
+    public static void stopDb() {
+        database.stop();
+    }
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.host", database::getHost);
+        registry.add("spring.data.mongodb.port", () -> database.getMappedPort(27017));
+        registry.add("spring.data.mongodb.database", () -> "test");
+    }
+}

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/PersistenceTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/PersistenceTests.java
@@ -1,0 +1,112 @@
+package shop.microservices.core.recommendation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import shop.microservices.core.recommendation.persistence.RecommendationEntity;
+import shop.microservices.core.recommendation.persistence.RecommendationRepository;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SuppressWarnings("ALL")
+@DataMongoTest
+class PersistenceTests extends MongoDbTestBase {
+
+    @Autowired
+    private RecommendationRepository repository;
+
+    private RecommendationEntity savedEntity;
+
+    @BeforeEach
+    void setupDb() {
+        repository.deleteAll();
+
+        RecommendationEntity entity = new RecommendationEntity(1, 2, "a", 3, "c");
+        savedEntity = repository.save(entity);
+
+        assertEqualsRecommendation(entity, savedEntity);
+    }
+
+    @Test
+    void create() {
+        RecommendationEntity newEntity = new RecommendationEntity(1, 3, "a", 3, "c");
+        repository.save(newEntity);
+
+        RecommendationEntity foundEntity = repository.findById(newEntity.getId()).get();
+        assertEqualsRecommendation(newEntity, foundEntity);
+
+        assertEquals(2, repository.count());
+    }
+
+    @Test
+    void update() {
+        savedEntity.setAuthor("a2");
+        repository.save(savedEntity);
+
+        RecommendationEntity foundEntity = repository.findById(savedEntity.getId()).get();
+        assertEquals(1, (long) foundEntity.getVersion());
+        assertEquals("a2", foundEntity.getAuthor());
+    }
+
+    @Test
+    void delete() {
+        repository.delete(savedEntity);
+        assertFalse(repository.existsById(savedEntity.getId()));
+    }
+
+    @Test
+    void getByProductId() {
+        List<RecommendationEntity> entityList = repository.findByProductId(savedEntity.getProductId());
+
+        assertThat(entityList, hasSize(1));
+        assertEqualsRecommendation(savedEntity, entityList.getFirst());
+    }
+
+    @Test
+    void duplicateError() {
+        assertThrows(DuplicateKeyException.class, () -> {
+            RecommendationEntity entity = new RecommendationEntity(1, 2, "a", 3, "c");
+            repository.save(entity);
+        });
+    }
+
+    @Test
+    void optimisticLockError() {
+        // Store the saved entity in two separate entity objects
+        RecommendationEntity entity1 = repository.findById(savedEntity.getId()).get();
+        RecommendationEntity entity2 = repository.findById(savedEntity.getId()).get();
+
+        // Update the entity using the first entity object
+        entity1.setAuthor("a1");
+        repository.save(entity1);
+
+        //  Update the entity using the second entity object.
+        // This should fail since the second entity now holds an old version number, i.e. an Optimistic Lock Error
+        assertThrows(OptimisticLockingFailureException.class, () -> {
+            entity2.setAuthor("a2");
+            repository.save(entity2);
+        });
+
+        // Get the updated entity from the database and verify its new state
+        RecommendationEntity updatedEntity = repository.findById(savedEntity.getId()).get();
+        assertEquals(1, (int) updatedEntity.getVersion());
+        assertEquals("a1", updatedEntity.getAuthor());
+    }
+
+    private void assertEqualsRecommendation(RecommendationEntity expectedEntity, RecommendationEntity actualEntity) {
+        assertEquals(expectedEntity.getId(), actualEntity.getId());
+        assertEquals(expectedEntity.getVersion(), actualEntity.getVersion());
+        assertEquals(expectedEntity.getProductId(), actualEntity.getProductId());
+        assertEquals(expectedEntity.getRecommendationId(), actualEntity.getRecommendationId());
+        assertEquals(expectedEntity.getAuthor(), actualEntity.getAuthor());
+        assertEquals(expectedEntity.getRating(), actualEntity.getRating());
+        assertEquals(expectedEntity.getContent(), actualEntity.getContent());
+    }
+}

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApiTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApiTests.java
@@ -1,55 +1,142 @@
 package shop.microservices.core.recommendation;
 
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
+import org.springframework.test.json.AbstractJsonContentAssert;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import shop.api.core.recommendation.Recommendation;
+import shop.microservices.core.recommendation.persistence.RecommendationRepository;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.HttpStatus.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
-@WebMvcTest
-public class RecommendationServiceApiTests {
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+public class RecommendationServiceApiTests extends MongoDbTestBase {
 
     @Autowired
     private MockMvcTester mockMvcTester;
 
-    @Test
-    public void testProductCompositeServiceApi() {
-        mockMvcTester.get()
-                .uri("/recommendation?productId=0")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .assertThat()
-                .hasStatus(HttpStatus.OK)
-                .hasContentType(MediaType.APPLICATION_JSON)
-                .bodyJson()
-                .hasPath("$[0].productId")
-                .hasPath("$[0].recommendationId")
-                .hasPath("$[0].author")
-                .hasPath("$[0].rate")
-                .hasPath("$[0].content")
-                .hasPath("$[0].serviceAddress");
+    @Autowired
+    private RecommendationRepository repository;
+
+    @BeforeEach
+    void setupDb() {
+        repository.deleteAll();
     }
 
     @Test
-    void testBadRequestForWrongParameterType() {
-        mockMvcTester.get()
-                .uri("/recommendation?productId=no-integer")
-                .accept(APPLICATION_JSON)
-                .exchange()
-                .assertThat()
-                .hasStatus(HttpStatus.BAD_REQUEST);
+    void getRecommendationsByProductId() {
+        int productId = 1;
+
+        postAndVerifyRecommendation(productId, 1, OK);
+        postAndVerifyRecommendation(productId, 2, OK);
+        postAndVerifyRecommendation(productId, 3, OK);
+
+        assertEquals(3, repository.findByProductId(productId).size());
+
+        getAndVerifyRecommendationsByProductId(productId, OK)
+                .hasPathSatisfying("$.length()", it -> it.assertThat().isEqualTo(3))
+                .hasPathSatisfying("$[2].productId", it -> it.assertThat().isEqualTo(productId))
+                .hasPathSatisfying("$[2].recommendationId", it -> it.assertThat().isEqualTo(3));
     }
 
     @Test
-    void testUnprocessableEntityForNegativeParameter() {
-        mockMvcTester.get()
-                .uri("/recommendation?productId=-1")
-                .accept(APPLICATION_JSON)
+    void duplicateError() {
+        int productId = 1;
+        int recommendationId = 1;
+
+        postAndVerifyRecommendation(productId, recommendationId, OK)
+                .hasPathSatisfying("$.productId", it -> it.assertThat().isEqualTo(productId))
+                .hasPathSatisfying("$.recommendationId", it -> it.assertThat().isEqualTo(recommendationId));
+
+        assertEquals(1, repository.count());
+
+        postAndVerifyRecommendation(productId, recommendationId, UNPROCESSABLE_ENTITY)
+                .hasPathSatisfying("$.path", it -> it.assertThat().isEqualTo("/recommendation"))
+                .hasPathSatisfying("$.message", it -> it.assertThat().isEqualTo("Duplicate key, Product Id: 1, Recommendation Id:1"));
+
+        assertEquals(1, repository.count());
+    }
+
+    @Test
+    void deleteRecommendations() {
+        int productId = 1;
+        int recommendationId = 1;
+
+        postAndVerifyRecommendation(productId, recommendationId, OK);
+        assertEquals(1, repository.findByProductId(productId).size());
+
+        deleteAndVerifyRecommendationsByProductId(productId, OK);
+        assertEquals(0, repository.findByProductId(productId).size());
+
+        deleteAndVerifyRecommendationsByProductId(productId, OK);
+    }
+
+    @Test
+    void getRecommendationsMissingParameter() {
+        getAndVerifyRecommendationsByProductId("", BAD_REQUEST);
+    }
+
+    @Test
+    void getRecommendationsInvalidParameter() {
+        getAndVerifyRecommendationsByProductId("?productId=no-integer", BAD_REQUEST);
+    }
+
+    @Test
+    void getRecommendationsNotFound() {
+        getAndVerifyRecommendationsByProductId("?productId=113", OK)
+                .hasPathSatisfying("$.length()", it -> it.assertThat().isEqualTo(0));
+    }
+
+    @Test
+    void getRecommendationsInvalidParameterNegativeValue() {
+        int productIdInvalid = -1;
+
+        getAndVerifyRecommendationsByProductId("?productId=" + productIdInvalid, UNPROCESSABLE_ENTITY)
+                .hasPathSatisfying("$.path", it -> it.assertThat().isEqualTo("/recommendation"))
+                .hasPathSatisfying("$.message", it -> it.assertThat().isEqualTo("Invalid productId: " + productIdInvalid));
+    }
+
+    private AbstractJsonContentAssert<?> getAndVerifyRecommendationsByProductId(int productId, HttpStatus expectedStatus) {
+        return getAndVerifyRecommendationsByProductId("?productId=" + productId, expectedStatus);
+    }
+
+    private AbstractJsonContentAssert<?> getAndVerifyRecommendationsByProductId(String productIdQuery, HttpStatus expectedStatus) {
+        return mockMvcTester.get()
+                .uri("/recommendation" + productIdQuery)
+                .contentType(APPLICATION_JSON)
                 .exchange()
                 .assertThat()
-                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY);
+                .hasStatus(expectedStatus)
+                .bodyJson();
+    }
+
+    private AbstractJsonContentAssert<?> postAndVerifyRecommendation(int productId, int recommendationId, HttpStatus expectedStatus) {
+        Recommendation recommendation = new Recommendation(productId, recommendationId, "Author " + recommendationId, recommendationId, "Content " + recommendationId, "SA");
+        return mockMvcTester.post()
+                .uri("/recommendation")
+                .contentType(APPLICATION_JSON)
+                .content(new Gson().toJson(recommendation))
+                .exchange()
+                .assertThat()
+                .hasStatus(expectedStatus)
+                .bodyJson();
+    }
+
+    private void deleteAndVerifyRecommendationsByProductId(int productId, HttpStatus expectedStatus) {
+        mockMvcTester.delete()
+                .uri("/recommendation?productId=" + productId)
+                .contentType(APPLICATION_JSON)
+                .exchange()
+                .assertThat()
+                .hasStatus(expectedStatus);
     }
 }

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class RecommendationServiceApplicationTests {
+public class RecommendationServiceApplicationTests extends MongoDbTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(properties = {"spring.flyway.enabled: false"})
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;


### PR DESCRIPTION
Implement MongoDB persistence for the Recommendation microservice.

- Create a Spring Data MongoDB entity RecommendationEntity mapped to the collection "recommendations".
  - Fields: productId, recommendationId, author, rating, content.
  - Use a compound unique index on (productId, recommendationId).
  - Include @Id and @Version fields.
- Create a RecommendationRepository extending CrudRepository<RecommendationEntity, String> with a method
List<RecommendationEntity> findByProductId(int productId).
 - Configure connection to MongoDB in application.yml and docker profile:
  - Default host: localhost, port: 27017, database: recommendation-db.
  - In Docker: host name mongodb.
- Update docker-compose.yml:
  - Add MongoDB service using mongo:6.0.4.
  - Expose port 27017.
  - Add healthcheck and depends_on for the recommendation service.
- In RecommendationServiceImpl:
  - Implement createRecommendation, getRecommendations, and deleteRecommendations using MongoDB repository.
  - Map between API (Recommendation) and Entity using helper methods.
  - Handle DuplicateKeyException and throw InvalidInputException with a descriptive message.
- Add MongoDB initialization log and ensure indexes are created on startup.