### PR TITLE
Recommendation Service: validate entities before persisting

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:recommendation-service:shop.microservices.core.recommendation.RecommendationServiceApiTests",
+      "microservices:recommendation-service:shop.microservices.core.recommendation.RecommendationValidationTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/microservices/recommendation-service/build.gradle
+++ b/microservices/recommendation-service/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation project(':util')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.google.code.gson:gson:2.13.1'

--- a/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/RecommendationServiceApplication.java
+++ b/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/RecommendationServiceApplication.java
@@ -6,6 +6,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.mapping.context.MappingContext;
@@ -15,10 +16,12 @@ import org.springframework.data.mongodb.core.index.IndexResolver;
 import org.springframework.data.mongodb.core.index.MongoPersistentEntityIndexResolver;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
+import shop.microservices.core.recommendation.persistence.MongoDbValidationConfig;
 import shop.microservices.core.recommendation.persistence.RecommendationEntity;
 
 @SpringBootApplication
 @ComponentScan("shop")
+@Import(MongoDbValidationConfig.class)
 public class RecommendationServiceApplication {
 
     private static final Logger LOG = LoggerFactory.getLogger(RecommendationServiceApplication.class);

--- a/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/persistence/MongoDbValidationConfig.java
+++ b/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/persistence/MongoDbValidationConfig.java
@@ -1,0 +1,15 @@
+package shop.microservices.core.recommendation.persistence;
+
+import jakarta.validation.Validator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.mapping.event.ValidatingEntityCallback;
+
+@Configuration
+public class MongoDbValidationConfig {
+
+    @Bean
+    public ValidatingEntityCallback validatingEntityCallback(Validator validator) {
+        return new ValidatingEntityCallback(validator);
+    }
+}

--- a/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/persistence/RecommendationEntity.java
+++ b/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/persistence/RecommendationEntity.java
@@ -1,5 +1,9 @@
 package shop.microservices.core.recommendation.persistence;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.Range;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
@@ -15,10 +19,15 @@ public class RecommendationEntity {
     @Version
     private Integer version;
 
+    @Min(0)
     private int productId;
+    @Min(0)
     private int recommendationId;
+    @NotBlank
     private String author;
+    @Range(min = 1, max = 5)
     private int rating;
+    @Size(min = 50, max = 200)
     private String content;
 
     public RecommendationEntity() {

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/PersistenceTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/PersistenceTests.java
@@ -3,7 +3,8 @@ package shop.microservices.core.recommendation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import shop.microservices.core.recommendation.persistence.RecommendationEntity;
@@ -16,8 +17,11 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("ALL")
-@DataMongoTest
+@AutoConfigureDataMongo
+@SpringBootTest
 class PersistenceTests extends MongoDbTestBase {
+
+    private static final String RECOMMENDATION_CONTENT = "Lorem ipsum dolor sit amet, consetetur sadipscingw";
 
     @Autowired
     private RecommendationRepository repository;
@@ -28,7 +32,7 @@ class PersistenceTests extends MongoDbTestBase {
     void setupDb() {
         repository.deleteAll();
 
-        RecommendationEntity entity = new RecommendationEntity(1, 2, "a", 3, "c");
+        RecommendationEntity entity = new RecommendationEntity(1, 2, "a", 3, RECOMMENDATION_CONTENT);
         savedEntity = repository.save(entity);
 
         assertEqualsRecommendation(entity, savedEntity);
@@ -36,7 +40,7 @@ class PersistenceTests extends MongoDbTestBase {
 
     @Test
     void create() {
-        RecommendationEntity newEntity = new RecommendationEntity(1, 3, "a", 3, "c");
+        RecommendationEntity newEntity = new RecommendationEntity(1, 3, "a", 3, RECOMMENDATION_CONTENT);
         repository.save(newEntity);
 
         RecommendationEntity foundEntity = repository.findById(newEntity.getId()).get();
@@ -72,7 +76,7 @@ class PersistenceTests extends MongoDbTestBase {
     @Test
     void duplicateError() {
         assertThrows(DuplicateKeyException.class, () -> {
-            RecommendationEntity entity = new RecommendationEntity(1, 2, "a", 3, "c");
+            RecommendationEntity entity = new RecommendationEntity(1, 2, "a", 3, RECOMMENDATION_CONTENT);
             repository.save(entity);
         });
     }

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApiTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApiTests.java
@@ -21,6 +21,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 public class RecommendationServiceApiTests extends MongoDbTestBase {
 
+    private static final String RECOMMENDATION_CONTENT = "Lorem ipsum dolor sit amet, consetetur sadipscingw";
+
     @Autowired
     private MockMvcTester mockMvcTester;
 
@@ -120,7 +122,7 @@ public class RecommendationServiceApiTests extends MongoDbTestBase {
     }
 
     private AbstractJsonContentAssert<?> postAndVerifyRecommendation(int productId, int recommendationId, HttpStatus expectedStatus) {
-        Recommendation recommendation = new Recommendation(productId, recommendationId, "Author " + recommendationId, recommendationId, "Content " + recommendationId, "SA");
+        Recommendation recommendation = new Recommendation(productId, recommendationId, "Author " + recommendationId, recommendationId, RECOMMENDATION_CONTENT + recommendationId, "SA");
         return mockMvcTester.post()
                 .uri("/recommendation")
                 .contentType(APPLICATION_JSON)

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class RecommendationServiceApplicationTests {
+public class RecommendationServiceApplicationTests extends MongoDbTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationValidationTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationValidationTests.java
@@ -1,0 +1,50 @@
+package shop.microservices.core.recommendation;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+import shop.microservices.core.recommendation.persistence.RecommendationEntity;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RecommendationValidationTests {
+
+    @Test
+    public void testRecommendationEntityValidationNegative() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = validatorFactory.getValidator();
+
+            var violations = validator.validate(
+                    new RecommendationEntity(-1, -1, "", -1, ""));
+
+            assertFalse(violations.isEmpty());
+            assertEquals(5, violations.size());
+            assertThat(violations)
+                    .extracting(it -> it.getPropertyPath() + " " + it.getMessage())
+                    .containsExactlyInAnyOrder(
+                            "recommendationId must be greater than or equal to 0",
+                            "content size must be between 50 and 200",
+                            "rating must be between 1 and 5",
+                            "productId must be greater than or equal to 0",
+                            "author must not be blank");
+        }
+    }
+
+    @Test
+    public void testRecommendationEntityValidationPositive() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = validatorFactory.getValidator();
+
+            var violations = validator.validate(
+                    new RecommendationEntity(
+                            0,
+                            0,
+                            "John Snow",
+                            4,
+                            "Lorem ipsum dolor sit amet, consetetur sadipscingw"));
+
+            assertTrue(violations.isEmpty());
+        }
+    }
+}

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(properties = {"spring.flyway.enabled: false"})
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;


### PR DESCRIPTION
- Add 'spring-boot-starter-validation' dependency to enable bean validation
- Introduce a configuration class named MongoDbValidationConfig in the persistence package to integrate bean validation with MongoDB entity persistence. The configuration must register a validator callback so that entities are automatically validated before being saved.
- Import the new validation configuration into the main RecommendationServiceApplication class to ensure it is active at runtime.
- Update the RecommendationEntity class by adding appropriate validation annotations for all relevant fields to enforce the following constraints: product and recommendation IDs must be non-negative; the author must not be blank; the rating must be within a defined numeric range; and the content must have a minimum and maximum length.
- Adjust existing persistence and API tests to use valid entity content that satisfies the new validation constraints.
- Add new test cases covering both valid and invalid entity scenarios to verify that constraint violations are detected as expected.
- Create a dedicated RecommendationValidationTests class to explicitly test entity validation rules, including both positive (valid) and negative (invalid) cases, and verify that all constraint violations are correctly reported.