### PR TITLE
Add the 'productId' parameter validation for all endpoints

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,12 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:product-composite-service:shop.microservices.composite.product.ProductCompositeApiTests.testUnprocessableEntityForNegativeParameter",
+      "microservices:product-service:shop.microservices.core.product.ProductServiceApiTests.testUnprocessableEntityForNegativeParameter",
+      "microservices:recommendation-service:shop.microservices.core.recommendation.RecommendationServiceApiTests.testUnprocessableEntityForNegativeParameter",
+      "microservices:review-service:shop.microservices.core.review.ReviewServiceApiTests.testUnprocessableEntityForNegativeParameter"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/api/src/main/java/shop/api/exceptions/InvalidInputException.java
+++ b/api/src/main/java/shop/api/exceptions/InvalidInputException.java
@@ -1,0 +1,8 @@
+package shop.api.exceptions;
+
+public class InvalidInputException extends RuntimeException {
+
+    public InvalidInputException(String message) {
+        super(message);
+    }
+}

--- a/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/ProductCompositeServiceApplication.java
+++ b/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/ProductCompositeServiceApplication.java
@@ -2,8 +2,10 @@ package shop.microservices.composite.product;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan("shop")
 public class ProductCompositeServiceApplication {
 
     public static void main(String[] args) {

--- a/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeServiceImpl.java
+++ b/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeServiceImpl.java
@@ -4,6 +4,7 @@ import org.springframework.web.bind.annotation.RestController;
 import shop.api.composite.product.ProductAggregate;
 import shop.api.composite.product.ProductCompositeService;
 import shop.api.composite.product.ServiceAddresses;
+import shop.api.exceptions.InvalidInputException;
 
 import java.util.List;
 
@@ -12,6 +13,9 @@ public class ProductCompositeServiceImpl implements ProductCompositeService {
 
     @Override
     public ProductAggregate getProduct(int productId) {
+        if (productId < 0)
+            throw new InvalidInputException("Invalid productId: " + productId);
+
         return new ProductAggregate(-1, "Something", 1, List.of(), List.of(), new ServiceAddresses("", "", "", ""));
     }
 }

--- a/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
+++ b/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
 @WebMvcTest
 public class ProductCompositeApiTests {
 
@@ -16,7 +18,7 @@ public class ProductCompositeApiTests {
     @Test
     public void testProductCompositeServiceApi() {
         mockMvcTester.get()
-                .uri("http://localhost:8080/product-composite/0")
+                .uri("/product-composite/0")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .assertThat()
@@ -31,5 +33,23 @@ public class ProductCompositeApiTests {
                 .hasPath("$.serviceAddresses");
     }
 
+    @Test
+    void testBadRequestForWrongParameterType() {
+        mockMvcTester.get()
+                .uri("/product-composite/no-integer")
+                .accept(APPLICATION_JSON)
+                .exchange()
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
 
+    @Test
+    void testUnprocessableEntityForNegativeParameter() {
+        mockMvcTester.get()
+                .uri("/product-composite/-1")
+                .accept(APPLICATION_JSON)
+                .exchange()
+                .assertThat()
+                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
 }

--- a/microservices/product-service/src/main/java/shop/microservices/core/product/ProductServiceApplication.java
+++ b/microservices/product-service/src/main/java/shop/microservices/core/product/ProductServiceApplication.java
@@ -2,12 +2,13 @@ package shop.microservices.core.product;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan("shop")
 public class ProductServiceApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(ProductServiceApplication.class, args);
     }
-
 }

--- a/microservices/product-service/src/main/java/shop/microservices/core/product/services/ProductServiceImpl.java
+++ b/microservices/product-service/src/main/java/shop/microservices/core/product/services/ProductServiceImpl.java
@@ -3,12 +3,16 @@ package shop.microservices.core.product.services;
 import org.springframework.web.bind.annotation.RestController;
 import shop.api.core.product.Product;
 import shop.api.core.product.ProductService;
+import shop.api.exceptions.InvalidInputException;
 
 @RestController
 public class ProductServiceImpl implements ProductService {
 
     @Override
     public Product getProduct(int productId) {
-        return new Product(-1, "Something", 1, "");
+        if (productId < 0)
+            throw new InvalidInputException("Invalid productId: " + productId);
+
+        return new Product(0, "Something", 1, "");
     }
 }

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApiTests.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApiTests.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
 @WebMvcTest
 public class ProductServiceApiTests {
 
@@ -16,7 +18,7 @@ public class ProductServiceApiTests {
     @Test
     public void testProductServiceApi() {
         mockMvcTester.get()
-                .uri("http://localhost:8080/product/0")
+                .uri("/product/0")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .assertThat()
@@ -27,5 +29,25 @@ public class ProductServiceApiTests {
                 .hasPath("$.name")
                 .hasPath("$.weight")
                 .hasPath("$.serviceAddress");
+    }
+
+    @Test
+    void testBadRequestForWrongParameterType() {
+        mockMvcTester.get()
+                .uri("/product/no-integer")
+                .accept(APPLICATION_JSON)
+                .exchange()
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void testUnprocessableEntityForNegativeParameter() {
+        mockMvcTester.get()
+                .uri("/product/-1")
+                .accept(APPLICATION_JSON)
+                .exchange()
+                .assertThat()
+                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY);
     }
 }

--- a/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/RecommendationServiceApplication.java
+++ b/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/RecommendationServiceApplication.java
@@ -2,12 +2,13 @@ package shop.microservices.core.recommendation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan("shop")
 public class RecommendationServiceApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(RecommendationServiceApplication.class, args);
     }
-
 }

--- a/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/services/RecommendationServiceImpl.java
+++ b/microservices/recommendation-service/src/main/java/shop/microservices/core/recommendation/services/RecommendationServiceImpl.java
@@ -3,6 +3,7 @@ package shop.microservices.core.recommendation.services;
 import org.springframework.web.bind.annotation.RestController;
 import shop.api.core.recommendation.Recommendation;
 import shop.api.core.recommendation.RecommendationService;
+import shop.api.exceptions.InvalidInputException;
 
 import java.util.List;
 
@@ -11,6 +12,9 @@ public class RecommendationServiceImpl implements RecommendationService {
 
     @Override
     public List<Recommendation> getRecommendations(int productId) {
+        if (productId < 0)
+            throw new InvalidInputException("Invalid productId: " + productId);
+
         return List.of(new Recommendation(0, 0, "", 0, "", ""));
     }
 }

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApiTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApiTests.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
 @WebMvcTest
 public class RecommendationServiceApiTests {
 
@@ -16,7 +18,7 @@ public class RecommendationServiceApiTests {
     @Test
     public void testProductCompositeServiceApi() {
         mockMvcTester.get()
-                .uri("http://localhost:8080/recommendation?productId=0")
+                .uri("/recommendation?productId=0")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .assertThat()
@@ -29,5 +31,25 @@ public class RecommendationServiceApiTests {
                 .hasPath("$[0].rate")
                 .hasPath("$[0].content")
                 .hasPath("$[0].serviceAddress");
+    }
+
+    @Test
+    void testBadRequestForWrongParameterType() {
+        mockMvcTester.get()
+                .uri("/recommendation?productId=no-integer")
+                .accept(APPLICATION_JSON)
+                .exchange()
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void testUnprocessableEntityForNegativeParameter() {
+        mockMvcTester.get()
+                .uri("/recommendation?productId=-1")
+                .accept(APPLICATION_JSON)
+                .exchange()
+                .assertThat()
+                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY);
     }
 }

--- a/microservices/review-service/src/main/java/shop/microservices/core/review/ReviewServiceApplication.java
+++ b/microservices/review-service/src/main/java/shop/microservices/core/review/ReviewServiceApplication.java
@@ -2,12 +2,13 @@ package shop.microservices.core.review;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan("shop")
 public class ReviewServiceApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(ReviewServiceApplication.class, args);
     }
-
 }

--- a/microservices/review-service/src/main/java/shop/microservices/core/review/services/ReviewServiceImpl.java
+++ b/microservices/review-service/src/main/java/shop/microservices/core/review/services/ReviewServiceImpl.java
@@ -3,6 +3,7 @@ package shop.microservices.core.review.services;
 import org.springframework.web.bind.annotation.RestController;
 import shop.api.core.review.Review;
 import shop.api.core.review.ReviewService;
+import shop.api.exceptions.InvalidInputException;
 
 import java.util.List;
 
@@ -11,6 +12,9 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     public List<Review> getReviews(int productId) {
+        if (productId < 0)
+            throw new InvalidInputException("Invalid productId: " + productId);
+
         return List.of(new Review(0, 0, "", "", "", ""));
     }
 }

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApiTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApiTests.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
 @WebMvcTest
 public class ReviewServiceApiTests {
 
@@ -16,7 +18,7 @@ public class ReviewServiceApiTests {
     @Test
     public void testProductCompositeServiceApi() {
         mockMvcTester.get()
-                .uri("http://localhost:8080/review?productId=0")
+                .uri("/review?productId=0")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .assertThat()
@@ -29,5 +31,25 @@ public class ReviewServiceApiTests {
                 .hasPath("$[0].subject")
                 .hasPath("$[0].content")
                 .hasPath("$[0].serviceAddress");
+    }
+
+    @Test
+    void testBadRequestForWrongParameterType() {
+        mockMvcTester.get()
+                .uri("/review?productId=no-integer")
+                .accept(APPLICATION_JSON)
+                .exchange()
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void testUnprocessableEntityForNegativeParameter() {
+        mockMvcTester.get()
+                .uri("/review?productId=-1")
+                .accept(APPLICATION_JSON)
+                .exchange()
+                .assertThat()
+                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY);
     }
 }

--- a/util/src/main/java/shop/util/http/GlobalControllerExceptionHandler.java
+++ b/util/src/main/java/shop/util/http/GlobalControllerExceptionHandler.java
@@ -1,0 +1,40 @@
+package shop.util.http;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import shop.api.exceptions.InvalidInputException;
+
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
+
+@RestControllerAdvice
+class GlobalControllerExceptionHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GlobalControllerExceptionHandler.class);
+
+    @ResponseStatus(UNPROCESSABLE_ENTITY)
+    @ExceptionHandler(InvalidInputException.class)
+    public @ResponseBody HttpErrorInfo handleInvalidInputException(
+            HttpServletRequest request,
+            InvalidInputException ex
+    ) {
+        return createHttpErrorInfo(UNPROCESSABLE_ENTITY, request, ex);
+    }
+
+    private HttpErrorInfo createHttpErrorInfo(
+            HttpStatus httpStatus,
+            HttpServletRequest request,
+            Exception ex
+    ) {
+        final String path = request.getRequestURI();
+        final String message = ex.getMessage();
+
+        LOG.debug("Returning HTTP status: {} for path: {}, message: {}", httpStatus, path, message);
+        return new HttpErrorInfo(httpStatus, path, message);
+    }
+}

--- a/util/src/main/java/shop/util/http/HttpErrorInfo.java
+++ b/util/src/main/java/shop/util/http/HttpErrorInfo.java
@@ -1,0 +1,16 @@
+package shop.util.http;
+
+import org.springframework.http.HttpStatus;
+
+import java.time.ZonedDateTime;
+
+public record HttpErrorInfo(HttpStatus httpStatus,
+                            String path,
+                            String message,
+                            ZonedDateTime timestamp
+) {
+
+    public HttpErrorInfo(HttpStatus httpStatus, String path, String message) {
+        this(httpStatus, path, message, ZonedDateTime.now());
+    }
+}


### PR DESCRIPTION
Add the 'productId' parameter validation for all endpoints
Handle negative productId across all services (ProductService, RecommendationService, ReviewService, ProductCompositeService):
- Throw InvalidInputException if productId < 0.
  - Exception message: "Invalid productId: <value>".
- Use a global @RestControllerAdvice to handle InvalidInputException.
  - Return HTTP 422 Unprocessable Entity.
  - JSON response must include:
    - httpStatus
    - path
    - message
    - timestamp
- For productId >= 0, return existing or dummy objects.
- Add @ComponentScan("shop") to the main class of each service.