### PR TITLE
Configure different ports for microservices to be able to run them all simultaneously

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,12 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:product-composite-service:shop.microservices.composite.product.ProductCompositeServiceApplicationTests",
+      "microservices:product-service:shop.microservices.core.product.ProductServiceApplicationTests",
+      "microservices:recommendation-service:shop.microservices.core.recommendation.RecommendationServiceApplicationTests",
+      "microservices:review-service:shop.microservices.core.review.ReviewServiceApplicationTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/microservices/product-composite-service/src/main/resources/application.yml
+++ b/microservices/product-composite-service/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+# macOS uses the '7000' port for the control center
+server.port: 7001

--- a/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeServiceApplicationTests.java
+++ b/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeServiceApplicationTests.java
@@ -1,0 +1,22 @@
+package shop.microservices.composite.product;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class ProductCompositeServiceApplicationTests {
+
+    @Autowired
+    private Environment environment;
+
+    @Test
+    public void correctPortIsUsed() {
+        assertEquals(
+                "7001",
+                environment.getProperty("server.port"));
+    }
+}

--- a/microservices/product-service/src/main/resources/application.yml
+++ b/microservices/product-service/src/main/resources/application.yml
@@ -1,0 +1,1 @@
+server.port: 7002

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
@@ -1,0 +1,22 @@
+package shop.microservices.core.product;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class ProductServiceApplicationTests {
+
+    @Autowired
+    private Environment environment;
+
+    @Test
+    public void correctPortIsUsed() {
+        assertEquals(
+                "7002",
+                environment.getProperty("server.port"));
+    }
+}

--- a/microservices/recommendation-service/src/main/resources/application.yml
+++ b/microservices/recommendation-service/src/main/resources/application.yml
@@ -1,0 +1,1 @@
+server.port: 7003

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
@@ -1,0 +1,22 @@
+package shop.microservices.core.recommendation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class RecommendationServiceApplicationTests {
+
+    @Autowired
+    private Environment environment;
+
+    @Test
+    public void correctPortIsUsed() {
+        assertEquals(
+                "7003",
+                environment.getProperty("server.port"));
+    }
+}

--- a/microservices/review-service/src/main/resources/application.yml
+++ b/microservices/review-service/src/main/resources/application.yml
@@ -1,0 +1,1 @@
+server.port: 7004

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -1,0 +1,22 @@
+package shop.microservices.core.review;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class ReviewServiceApplicationTests {
+
+    @Autowired
+    private Environment environment;
+
+    @Test
+    public void correctPortIsUsed() {
+        assertEquals(
+                "7004",
+                environment.getProperty("server.port"));
+    }
+}


### PR DESCRIPTION
Configure different ports for microservices to be able to run them all simultaneously
For each microservice, set the server port in the YAML configuration file:
- Product composite service: port 7001
- Product service: port 7002
- Recommendation service: port 7003
- Review service: port 7004
The YAML file must contain the line:
server.port: <port_number>