### PR TITLE
Add OpenAPI documentation

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:product-composite-service:shop.microservices.composite.product.OpenApiTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-common:2.8.9'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/api/src/main/java/shop/api/composite/product/ProductCompositeService.java
+++ b/api/src/main/java/shop/api/composite/product/ProductCompositeService.java
@@ -1,8 +1,13 @@
 package shop.api.composite.product;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
+@Tag(name = "ProductComposite", description = "REST API for composite product information.")
 public interface ProductCompositeService {
 
     /**
@@ -11,6 +16,15 @@ public interface ProductCompositeService {
      * @param productId ID of the product
      * @return the composite product info, if found, else null
      */
+    @Operation(
+            summary = "${api.product-composite.get-composite-product.description}",
+            description = "${api.product-composite.get-composite-product.notes}")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "${api.responseCodes.ok.description}"),
+            @ApiResponse(responseCode = "400", description = "${api.responseCodes.badRequest.description}"),
+            @ApiResponse(responseCode = "404", description = "${api.responseCodes.notFound.description}"),
+            @ApiResponse(responseCode = "422", description = "${api.responseCodes.unprocessableEntity.description}")
+    })
     @GetMapping(
             value = "/product-composite/{productId}",
             produces = "application/json")

--- a/microservices/product-composite-service/build.gradle
+++ b/microservices/product-composite-service/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation project(':util')
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/OpenApiConfiguration.java
+++ b/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/OpenApiConfiguration.java
@@ -1,0 +1,61 @@
+package shop.microservices.composite.product;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfiguration {
+
+    @Value("${api.common.version}")
+    String apiVersion;
+    @Value("${api.common.title}")
+    String apiTitle;
+    @Value("${api.common.description}")
+    String apiDescription;
+    @Value("${api.common.termsOfService}")
+    String apiTermsOfService;
+    @Value("${api.common.license}")
+    String apiLicense;
+    @Value("${api.common.licenseUrl}")
+    String apiLicenseUrl;
+    @Value("${api.common.externalDocDesc}")
+    String apiExternalDocDesc;
+    @Value("${api.common.externalDocUrl}")
+    String apiExternalDocUrl;
+    @Value("${api.common.contact.name}")
+    String apiContactName;
+    @Value("${api.common.contact.url}")
+    String apiContactUrl;
+    @Value("${api.common.contact.email}")
+    String apiContactEmail;
+
+    /**
+     * Will exposed on $HOST:$PORT/swagger-ui.html
+     *
+     * @return the common OpenAPI documentation
+     */
+    @Bean
+    public OpenAPI getOpenApiDocumentation() {
+        return new OpenAPI()
+                .info(new Info().title(apiTitle)
+                        .description(apiDescription)
+                        .version(apiVersion)
+                        .contact(new Contact()
+                                .name(apiContactName)
+                                .url(apiContactUrl)
+                                .email(apiContactEmail))
+                        .termsOfService(apiTermsOfService)
+                        .license(new License()
+                                .name(apiLicense)
+                                .url(apiLicenseUrl)))
+                .externalDocs(new ExternalDocumentation()
+                        .description(apiExternalDocDesc)
+                        .url(apiExternalDocUrl));
+    }
+}

--- a/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/ProductCompositeServiceApplication.java
+++ b/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/ProductCompositeServiceApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @ComponentScan("shop")
+@Import(OpenApiConfiguration.class)
 public class ProductCompositeServiceApplication {
 
     public static void main(String[] args) {

--- a/microservices/product-composite-service/src/main/resources/application.yml
+++ b/microservices/product-composite-service/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 # macOS uses the '7000' port for the control center
 server.port: 7001
 
+spring.config.import: classpath:openapi-config.yml
+
 app:
   product-service:
     host: localhost

--- a/microservices/product-composite-service/src/main/resources/openapi-config.yml
+++ b/microservices/product-composite-service/src/main/resources/openapi-config.yml
@@ -1,0 +1,56 @@
+springdoc:
+  swagger-ui.path: /openapi/swagger-ui.html
+  api-docs.path: /openapi/v3/api-docs
+  packagesToScan: shop.microservices.composite.product
+  pathsToMatch: /**
+
+api:
+  common:
+    version: 3.0.0
+    title: Sample API
+    description: Description of the API...
+    termsOfService: MY TERMS OF SERVICE
+    license: MY LICENSE
+    licenseUrl: MY LICENSE URL
+
+    externalDocDesc: MY WIKI PAGE
+    externalDocUrl: MY WIKI URL
+    contact:
+      name: NAME OF CONTACT
+      url: URL TO CONTACT
+      email: contact@mail.com
+
+  responseCodes:
+    ok.description: OK
+    badRequest.description: Bad Request, invalid format of the request. See response message for more information
+    notFound.description: Not found, the specified id does not exist
+    unprocessableEntity.description: Unprocessable entity, input parameters caused the processing to fail. See response message for more information
+
+  product-composite:
+    get-composite-product:
+      description: Returns a composite view of the specified product id
+      notes: |
+        # Normal response
+        If the requested product id is found the method will return information regarding:
+        1. Base product information
+        1. Reviews
+        1. Recommendations
+        1. Service Addresses\n(technical information regarding the addresses of the microservices that created the response)
+
+        # Expected partial and error responses
+        In the following cases, only a partial response be created (used to simplify testing of error conditions)
+
+        ## Product id 113
+        200 - Ok, but no recommendations will be returned
+
+        ## Product id 213
+        200 - Ok, but no reviews will be returned
+
+        ## Non numerical product id
+        400 - A **Bad Request** error will be returned
+
+        ## Product id 13
+        404 - A **Not Found** error will be returned
+
+        ## Negative product ids
+        422 - An **Unprocessable Entity** error will be returned

--- a/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/OpenApiTests.java
+++ b/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/OpenApiTests.java
@@ -1,0 +1,36 @@
+package shop.microservices.composite.product;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class OpenApiTests {
+
+    @Autowired
+    private MockMvcTester mockMvcTester;
+
+    @Test
+    public void testSwaggerUi() {
+        mockMvcTester.get()
+                .uri("/openapi/swagger-ui/index.html")
+                .exchange()
+                .assertThat()
+                .hasStatus(HttpStatus.OK);
+    }
+
+    @Test
+    public void testOpenApiDocs() {
+        mockMvcTester.get()
+                .uri("/openapi/v3/api-docs")
+                .exchange()
+                .assertThat()
+                .hasStatus(HttpStatus.OK)
+                .hasContentType(MediaType.APPLICATION_JSON);
+    }
+}


### PR DESCRIPTION
Add OpenAPI (Swagger) documentation to the Spring Boot service using springdoc-openapi. The service must expose two endpoints: /openapi/swagger-ui.html for Swagger UI and /openapi/v3/api-docs for the OpenAPI JSON specification. Create a configuration class that defines the OpenAPI bean with complete metadata (title, version, description, terms of service, license, contact, external docs) and import it into the main application. Annotate all relevant services/controllers with OpenAPI tags, operation summaries, and response codes to ensure consistent, reproducible documentation across different developers.