### PR TITLE
Review Service: enable reviews persisting

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:review-service:shop.microservices.core.review.PersistenceTests",
+      "microservices:review-service:shop.microservices.core.review.ReviewServiceApiTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/api/src/main/java/shop/api/core/review/Review.java
+++ b/api/src/main/java/shop/api/core/review/Review.java
@@ -8,4 +8,7 @@ public record Review(
         String content,
         String serviceAddress
 ) {
+    public Review withServiceAddress(String serviceAddress) {
+        return new Review(productId, reviewId, author, subject, content, serviceAddress);
+    }
 }

--- a/api/src/main/java/shop/api/core/review/ReviewService.java
+++ b/api/src/main/java/shop/api/core/review/ReviewService.java
@@ -1,11 +1,34 @@
 package shop.api.core.review;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 public interface ReviewService {
+
+    /**
+     * Sample usage, see below.
+     * <p>
+     * curl -X POST $HOST:$PORT/review \
+     * -H "Content-Type: application/json" --data \
+     * '{"productId":123,"reviewId":456,"author":"me","subject":"yada, yada, yada","content":"yada, yada, yada"}'
+     *
+     * @param body A JSON representation of the new review
+     * @return A JSON representation of the newly created review
+     */
+    @PostMapping(
+            value = "/review",
+            consumes = "application/json",
+            produces = "application/json")
+    Review createReview(@RequestBody Review body);
+
+    /**
+     * Sample usage: "curl -X DELETE $HOST:$PORT/review?productId=1".
+     *
+     * @param productId ID of the product
+     */
+    @DeleteMapping(value = "/review")
+    void deleteReviews(@RequestParam int productId);
 
     /**
      * Sample usage: "curl $HOST:$PORT/review?productId=1".

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     mem_limit: 512m
     environment:
       - SPRING_PROFILES_ACTIVE=docker
+    depends_on:
+      mysql:
+        condition: service_healthy
 
   product-composite:
     build: microservices/product-composite-service
@@ -26,3 +29,19 @@ services:
       - "8080:8080"
     environment:
       - SPRING_PROFILES_ACTIVE=docker
+
+  mysql:
+    image: mysql:8.0.32
+    mem_limit: 512m
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=rootpwd
+      - MYSQL_DATABASE=review-db
+      - MYSQL_USER=user
+      - MYSQL_PASSWORD=pwd
+    healthcheck:
+      test: "/usr/bin/mysql --user=user --password=pwd --execute \"SHOW DATABASES;\""
+      interval: 5s
+      timeout: 2s
+      retries: 60

--- a/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeIntegration.java
+++ b/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeIntegration.java
@@ -115,6 +115,17 @@ public class ProductCompositeIntegration implements ProductService, Recommendati
         }
     }
 
+    @Override
+    public Review createReview(Review body) {
+        return restTemplate.postForObject(reviewServiceUrl, body, Review.class);
+    }
+
+    @Override
+    public void deleteReviews(int productId) {
+        String url = reviewServiceUrl + "?productId=" + productId;
+        restTemplate.delete(url);
+    }
+
     private String getErrorMessage(HttpClientErrorException ex) {
         try {
             return mapper.readValue(ex.getResponseBodyAsString(), HttpErrorInfo.class).getMessage();

--- a/microservices/review-service/build.gradle
+++ b/microservices/review-service/build.gradle
@@ -23,8 +23,14 @@ dependencies {
     implementation project(':api')
     implementation project(':util')
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'com.mysql:mysql-connector-j'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.google.code.gson:gson:2.13.1'
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql'
 }
 
 tasks.withType(Test).configureEach {

--- a/microservices/review-service/src/main/java/shop/microservices/core/review/ReviewServiceApplication.java
+++ b/microservices/review-service/src/main/java/shop/microservices/core/review/ReviewServiceApplication.java
@@ -1,14 +1,22 @@
 package shop.microservices.core.review;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 @ComponentScan("shop")
 public class ReviewServiceApplication {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ReviewServiceApplication.class);
+
     public static void main(String[] args) {
-        SpringApplication.run(ReviewServiceApplication.class, args);
+        ConfigurableApplicationContext ctx = SpringApplication.run(ReviewServiceApplication.class, args);
+
+        String mySqlUrl = ctx.getEnvironment().getProperty("spring.datasource.url");
+        LOG.info("Connected to MySQL: {}", mySqlUrl);
     }
 }

--- a/microservices/review-service/src/main/java/shop/microservices/core/review/persistence/ReviewEntity.java
+++ b/microservices/review-service/src/main/java/shop/microservices/core/review/persistence/ReviewEntity.java
@@ -1,0 +1,90 @@
+package shop.microservices.core.review.persistence;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "reviews", indexes = {
+        @Index(name = "reviews_unique_idx", unique = true, columnList = "productId,reviewId")
+})
+public class ReviewEntity {
+
+    @Id
+    @GeneratedValue
+    private int id;
+
+    @Version
+    private int version;
+
+    private int productId;
+    private int reviewId;
+    private String author;
+    private String subject;
+    private String content;
+
+    public ReviewEntity() {
+    }
+
+    public ReviewEntity(int productId, int reviewId, String author, String subject, String content) {
+        this.productId = productId;
+        this.reviewId = reviewId;
+        this.author = author;
+        this.subject = subject;
+        this.content = content;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public int getProductId() {
+        return productId;
+    }
+
+    public void setProductId(int productId) {
+        this.productId = productId;
+    }
+
+    public int getReviewId() {
+        return reviewId;
+    }
+
+    public void setReviewId(int reviewId) {
+        this.reviewId = reviewId;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/microservices/review-service/src/main/java/shop/microservices/core/review/persistence/ReviewRepository.java
+++ b/microservices/review-service/src/main/java/shop/microservices/core/review/persistence/ReviewRepository.java
@@ -1,0 +1,12 @@
+package shop.microservices.core.review.persistence;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface ReviewRepository extends CrudRepository<ReviewEntity, Integer> {
+
+    @Transactional(readOnly = true)
+    List<ReviewEntity> findByProductId(int productId);
+}

--- a/microservices/review-service/src/main/java/shop/microservices/core/review/services/MappingUtils.java
+++ b/microservices/review-service/src/main/java/shop/microservices/core/review/services/MappingUtils.java
@@ -1,0 +1,39 @@
+package shop.microservices.core.review.services;
+
+import shop.api.core.review.Review;
+import shop.microservices.core.review.persistence.ReviewEntity;
+
+import java.util.List;
+
+public final class MappingUtils {
+
+    private MappingUtils() {
+    }
+
+    public static ReviewEntity apiToEntity(Review review) {
+        return new ReviewEntity(
+                review.productId(),
+                review.reviewId(),
+                review.author(),
+                review.subject(),
+                review.content()
+        );
+    }
+
+    public static Review entityToApi(ReviewEntity reviewEntity) {
+        return new Review(
+                reviewEntity.getProductId(),
+                reviewEntity.getReviewId(),
+                reviewEntity.getAuthor(),
+                reviewEntity.getSubject(),
+                reviewEntity.getContent(),
+                null
+        );
+    }
+
+    public static List<Review> entityListToApiList(List<ReviewEntity> reviewEntityList) {
+        return reviewEntityList.stream()
+                .map(MappingUtils::entityToApi)
+                .toList();
+    }
+}

--- a/microservices/review-service/src/main/java/shop/microservices/core/review/services/ReviewServiceImpl.java
+++ b/microservices/review-service/src/main/java/shop/microservices/core/review/services/ReviewServiceImpl.java
@@ -1,20 +1,58 @@
 package shop.microservices.core.review.services;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.web.bind.annotation.RestController;
 import shop.api.core.review.Review;
 import shop.api.core.review.ReviewService;
 import shop.api.exceptions.InvalidInputException;
+import shop.microservices.core.review.persistence.ReviewEntity;
+import shop.microservices.core.review.persistence.ReviewRepository;
+import shop.util.http.ServiceUtil;
 
 import java.util.List;
 
+import static shop.microservices.core.review.services.MappingUtils.*;
+
 @RestController
 public class ReviewServiceImpl implements ReviewService {
+
+    private final ReviewRepository repository;
+
+    private final ServiceUtil serviceUtil;
+
+    @Autowired
+    public ReviewServiceImpl(ReviewRepository repository, ServiceUtil serviceUtil) {
+        this.repository = repository;
+        this.serviceUtil = serviceUtil;
+    }
+
+    @Override
+    public Review createReview(Review body) {
+        try {
+            ReviewEntity entity = apiToEntity(body);
+            ReviewEntity newEntity = repository.save(entity);
+
+            return entityToApi(newEntity);
+        } catch (DataIntegrityViolationException dive) {
+            throw new InvalidInputException("Duplicate key, Product Id: " + body.productId() + ", Review Id:" + body.reviewId());
+        }
+    }
 
     @Override
     public List<Review> getReviews(int productId) {
         if (productId < 0)
             throw new InvalidInputException("Invalid productId: " + productId);
 
-        return List.of(new Review(0, 0, "", "", "", ""));
+        List<ReviewEntity> entityList = repository.findByProductId(productId);
+        return entityListToApiList(entityList)
+                .stream()
+                .map(r -> r.withServiceAddress(serviceUtil.getServiceAddress()))
+                .toList();
+    }
+
+    @Override
+    public void deleteReviews(int productId) {
+        repository.deleteAll(repository.findByProductId(productId));
     }
 }

--- a/microservices/review-service/src/main/resources/application.yml
+++ b/microservices/review-service/src/main/resources/application.yml
@@ -1,5 +1,29 @@
 server.port: 7004
+
+spring.datasource:
+  url: jdbc:mysql://localhost/review-db
+  username: user
+  password: pwd
+
+spring.datasource.hikari.initializationFailTimeout: 60000
+
+spring.sql.init:
+  mode: always
+  schema-locations: classpath:db/init/init.sql
+  platform: mysql
+
+spring.jpa:
+  hibernate:
+    ddl-auto: none
+  show-sql: true
+
+logging:
+  level:
+    org.springframework.web.*: DEBUG
 ---
 spring.config.activate.on-profile: docker
 
 server.port: 8080
+
+spring.datasource:
+  url: jdbc:mysql://mysql/review-db

--- a/microservices/review-service/src/main/resources/db/init/init.sql
+++ b/microservices/review-service/src/main/resources/db/init/init.sql
@@ -1,0 +1,34 @@
+-- Create a database if it doesn't exist
+CREATE DATABASE IF NOT EXISTS `review-db`;
+
+-- Use the review-db database
+USE `review-db`;
+
+-- Drop the tables if they exist to ensure a clean state
+DROP TABLE IF EXISTS reviews;
+DROP TABLE IF EXISTS reviews_seq;
+
+-- Create the 'reviews' table
+CREATE TABLE reviews
+(
+    id         INT NOT NULL AUTO_INCREMENT,
+    version    INT NOT NULL DEFAULT 0,
+    product_id INT NOT NULL,
+    review_id  INT NOT NULL,
+    author     VARCHAR(255),
+    subject    VARCHAR(255),
+    content    TEXT,
+    PRIMARY KEY (id),
+    UNIQUE INDEX reviews_unique_idx (product_id, review_id)
+);
+
+-- Create the sequence table for Hibernate
+CREATE TABLE reviews_seq
+(
+    next_val BIGINT NOT NULL,
+    PRIMARY KEY (next_val)
+);
+
+-- Initialize the sequence with a starting value
+INSERT INTO reviews_seq
+VALUES (1);

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/MySqlTestBase.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/MySqlTestBase.java
@@ -1,0 +1,36 @@
+package shop.microservices.core.review;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MySQLContainer;
+
+public abstract class MySqlTestBase {
+
+    // Extend startup timeout since a MySQLContainer with MySQL 8 starts very slow on Win10/WSL2
+    private static final JdbcDatabaseContainer<?> database =
+            new MySQLContainer<>("mysql:8.0.32")
+                    .withStartupTimeoutSeconds(300)
+                    .withDatabaseName("review-db")
+                    .withUsername("user")
+                    .withPassword("pwd");
+
+    @BeforeAll
+    public static void startDb() {
+        database.start();
+    }
+
+    @AfterAll
+    public static void stopDb() {
+        database.stop();
+    }
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", database::getJdbcUrl);
+        registry.add("spring.datasource.username", database::getUsername);
+        registry.add("spring.datasource.password", database::getPassword);
+    }
+}

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/PersistenceTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/PersistenceTests.java
@@ -1,0 +1,118 @@
+package shop.microservices.core.review;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.transaction.annotation.Transactional;
+import shop.microservices.core.review.persistence.ReviewEntity;
+import shop.microservices.core.review.persistence.ReviewRepository;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.transaction.annotation.Propagation.NOT_SUPPORTED;
+
+@DataJpaTest
+@Transactional(propagation = NOT_SUPPORTED)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class PersistenceTests extends MySqlTestBase {
+
+    @Autowired
+    private ReviewRepository repository;
+
+    private ReviewEntity savedEntity;
+
+    @BeforeEach
+    void setupDb() {
+        repository.deleteAll();
+
+        ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", "c");
+        savedEntity = repository.save(entity);
+
+        assertEqualsReview(entity, savedEntity);
+    }
+
+    @Test
+    void create() {
+        ReviewEntity newEntity = new ReviewEntity(1, 3, "a", "s", "c");
+        repository.save(newEntity);
+
+        ReviewEntity foundEntity = repository.findById(newEntity.getId()).get();
+        assertEqualsReview(newEntity, foundEntity);
+
+        assertEquals(2, repository.count());
+    }
+
+    @Test
+    void update() {
+        savedEntity.setAuthor("a2");
+        repository.save(savedEntity);
+
+        ReviewEntity foundEntity = repository.findById(savedEntity.getId()).get();
+        assertEquals(1, (long) foundEntity.getVersion());
+        assertEquals("a2", foundEntity.getAuthor());
+    }
+
+    @Test
+    void delete() {
+        repository.delete(savedEntity);
+        Assertions.assertFalse(repository.existsById(savedEntity.getId()));
+    }
+
+    @Test
+    void getByProductId() {
+        List<ReviewEntity> entityList = repository.findByProductId(savedEntity.getProductId());
+
+        assertThat(entityList, hasSize(1));
+        assertEqualsReview(savedEntity, entityList.getFirst());
+    }
+
+    @Test
+    void duplicateError() {
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", "c");
+            repository.save(entity);
+        });
+    }
+
+    @Test
+    void optimisticLockError() {
+        // Store the saved entity in two separate entity objects
+        ReviewEntity entity1 = repository.findById(savedEntity.getId()).get();
+        ReviewEntity entity2 = repository.findById(savedEntity.getId()).get();
+
+        // Update the entity using the first entity object
+        entity1.setAuthor("a1");
+        repository.save(entity1);
+
+        // Update the entity using the second entity object.
+        // This should fail since the second entity now holds an old version number, i.e., an Optimistic Lock Error
+        assertThrows(OptimisticLockingFailureException.class, () -> {
+            entity2.setAuthor("a2");
+            repository.save(entity2);
+        });
+
+        // Get the updated entity from the database and verify its new state
+        ReviewEntity updatedEntity = repository.findById(savedEntity.getId()).get();
+        assertEquals(1, updatedEntity.getVersion());
+        assertEquals("a1", updatedEntity.getAuthor());
+    }
+
+    private void assertEqualsReview(ReviewEntity expectedEntity, ReviewEntity actualEntity) {
+        assertEquals(expectedEntity.getId(), actualEntity.getId());
+        assertEquals(expectedEntity.getVersion(), actualEntity.getVersion());
+        assertEquals(expectedEntity.getProductId(), actualEntity.getProductId());
+        assertEquals(expectedEntity.getReviewId(), actualEntity.getReviewId());
+        assertEquals(expectedEntity.getAuthor(), actualEntity.getAuthor());
+        assertEquals(expectedEntity.getSubject(), actualEntity.getSubject());
+        assertEquals(expectedEntity.getContent(), actualEntity.getContent());
+    }
+}

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;

--- a/util/src/main/java/shop/util/http/GlobalControllerExceptionHandler.java
+++ b/util/src/main/java/shop/util/http/GlobalControllerExceptionHandler.java
@@ -1,6 +1,7 @@
 package shop.util.http;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.apache.coyote.BadRequestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -10,12 +11,22 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import shop.api.exceptions.InvalidInputException;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 @RestControllerAdvice
 class GlobalControllerExceptionHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(GlobalControllerExceptionHandler.class);
+
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler(BadRequestException.class)
+    public @ResponseBody HttpErrorInfo handleBadRequestExceptions(
+            HttpServletRequest request,
+            BadRequestException ex
+    ) {
+        return createHttpErrorInfo(BAD_REQUEST, request, ex);
+    }
 
     @ResponseStatus(UNPROCESSABLE_ENTITY)
     @ExceptionHandler(InvalidInputException.class)


### PR DESCRIPTION
Review Service: enable reviews persisting. 
- Add a Spring Data JPA entity `ReviewEntity` with fields:
   - productId (int)
   - reviewId (int)
   - author (String)
   - subject (String)
   - content (String)
   - id (auto-generated primary key)
   - version (int)
   - Unique constraint on (productId, reviewId)
- Add `ReviewRepository` extending `CrudRepository<ReviewEntity, Integer>`.
- Create `ReviewService` REST API with:
   - POST /review → creates a review
   - DELETE /review?productId=X → deletes all reviews for product
   - GET /review?productId=X → returns all reviews for product
- Configure MySQL connection:
   - DB name: `review-db`, user: `user`, password: `pwd`
   - Use Hikari datasource with initialization timeout
- Update docker-compose to launch MySQL container with healthcheck.
- Include SQL init scripts for creating tables and sequences.
- Add mapping utilities between `Review` API object and `ReviewEntity`.