### PR TITLE
Review Service: add Flyway for database migrations

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:review-service:shop.microservices.core.review.ReviewDbMigrationTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/microservices/review-service/build.gradle
+++ b/microservices/review-service/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.5.3'
     implementation 'com.mysql:mysql-connector-j'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql:11.10.3'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.google.code.gson:gson:2.13.1'

--- a/microservices/review-service/src/main/resources/application.yml
+++ b/microservices/review-service/src/main/resources/application.yml
@@ -7,16 +7,6 @@ spring.datasource:
 
 spring.datasource.hikari.initializationFailTimeout: 60000
 
-spring.sql.init:
-  mode: always
-  schema-locations: classpath:db/init/init.sql
-  platform: mysql
-
-spring.jpa:
-  hibernate:
-    ddl-auto: none
-  show-sql: true
-
 logging:
   level:
     org.springframework.web.*: DEBUG

--- a/microservices/review-service/src/main/resources/db/migration/V1__.sql
+++ b/microservices/review-service/src/main/resources/db/migration/V1__.sql
@@ -1,0 +1,34 @@
+-- Create a database if it doesn't exist
+CREATE DATABASE IF NOT EXISTS `review-db`;
+
+-- Use the review-db database
+USE `review-db`;
+
+-- Drop the tables if they exist to ensure a clean state
+DROP TABLE IF EXISTS reviews;
+DROP TABLE IF EXISTS reviews_seq;
+
+-- Create the 'reviews' table
+CREATE TABLE reviews
+(
+    id         INT NOT NULL AUTO_INCREMENT,
+    version    INT NOT NULL DEFAULT 0,
+    product_id INT NOT NULL,
+    review_id  INT NOT NULL,
+    author     VARCHAR(255),
+    subject    VARCHAR(255),
+    content    VARCHAR(200),
+    PRIMARY KEY (id),
+    UNIQUE INDEX reviews_unique_idx (product_id, review_id)
+);
+
+-- Create the sequence table for Hibernate
+CREATE TABLE reviews_seq
+(
+    next_val BIGINT NOT NULL,
+    PRIMARY KEY (next_val)
+);
+
+-- Initialize the sequence with a starting value
+INSERT INTO reviews_seq
+VALUES (1);

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewDbMigrationTest.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewDbMigrationTest.java
@@ -1,0 +1,45 @@
+package shop.microservices.core.review;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(properties = {
+        "spring.flyway.clean-disabled: false"
+})
+public class ReviewDbMigrationTest extends MySqlTestBase {
+
+    @Autowired
+    private Flyway flyway;
+
+    @Autowired
+    private JdbcClient jdbcClient;
+
+    @Test
+    void testMigration() {
+        flyway.clean();
+        flyway.migrate();
+
+        BigInteger dbMajorVersion = flyway.info().current().getVersion().getMajor();
+
+        assertThat(dbMajorVersion)
+                .isEqualTo(1);
+
+        try {
+            //noinspection SqlDialectInspection
+            var rows = jdbcClient.sql("select review_id from reviews")
+                    .query()
+                    .listOfRows();
+
+            assertThat(rows.size()).isEqualTo(0);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(properties = {"spring.flyway.enabled: false"})
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;


### PR DESCRIPTION
- Add Flyway dependencies to manage DB schema migrations
- Add 'V1__' migration script to create 'reviews' table with constraints
- Add `ReviewDbMigrationTest` to:
  - Clean and migrate Flyway
  - Assert that migration version = 1
  - Assert that table `reviews` is empty