### PR TITLE
Review Service: store a date of a review

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,13 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:product-composite-service:shop.microservices.composite.product.ProductCompositeApiTests",
+      "microservices:review-service:shop.microservices.core.review.PersistenceTests",
+      "microservices:review-service:shop.microservices.core.review.ReviewDbMigrationTest",
+      "microservices:review-service:shop.microservices.core.review.ReviewServiceApiTests",
+      "microservices:review-service:shop.microservices.core.review.ReviewValidationTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/api/src/main/java/shop/api/core/review/Review.java
+++ b/api/src/main/java/shop/api/core/review/Review.java
@@ -1,14 +1,17 @@
 package shop.api.core.review;
 
+import java.time.LocalDate;
+
 public record Review(
         int productId,
         int reviewId,
         String author,
         String subject,
         String content,
+        LocalDate date,
         String serviceAddress
 ) {
     public Review withServiceAddress(String serviceAddress) {
-        return new Review(productId, reviewId, author, subject, content, serviceAddress);
+        return new Review(productId, reviewId, author, subject, content, date, serviceAddress);
     }
 }

--- a/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
+++ b/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
@@ -13,6 +13,8 @@ import shop.api.core.review.Review;
 import shop.api.exceptions.InvalidInputException;
 import shop.microservices.composite.product.services.ProductCompositeIntegration;
 
+import java.time.LocalDate;
+
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.OK;
@@ -41,7 +43,7 @@ public class ProductCompositeApiTests {
                 .thenReturn(singletonList(new Recommendation(PRODUCT_ID_OK, 1, "author", 1, "content", "mock address")));
 
         when(compositeIntegration.getReviews(PRODUCT_ID_OK))
-                .thenReturn(singletonList(new Review(PRODUCT_ID_OK, 1, "author", "subject", "content", "mock address")));
+                .thenReturn(singletonList(new Review(PRODUCT_ID_OK, 1, "author", "subject", "content", LocalDate.now(), "mock address")));
     }
 
     @Test

--- a/microservices/review-service/src/main/java/shop/microservices/core/review/persistence/ReviewEntity.java
+++ b/microservices/review-service/src/main/java/shop/microservices/core/review/persistence/ReviewEntity.java
@@ -3,7 +3,10 @@ package shop.microservices.core.review.persistence;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "reviews", indexes = {
@@ -12,7 +15,7 @@ import jakarta.validation.constraints.Size;
 public class ReviewEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
     @Version
@@ -28,16 +31,19 @@ public class ReviewEntity {
     private String subject;
     @Size(min = 50, max = 200)
     private String content;
+    @NotNull
+    private LocalDate date;
 
     public ReviewEntity() {
     }
 
-    public ReviewEntity(int productId, int reviewId, String author, String subject, String content) {
+    public ReviewEntity(int productId, int reviewId, String author, String subject, String content, LocalDate date) {
         this.productId = productId;
         this.reviewId = reviewId;
         this.author = author;
         this.subject = subject;
         this.content = content;
+        this.date = date;
     }
 
     public int getId() {
@@ -94,5 +100,13 @@ public class ReviewEntity {
 
     public void setContent(String content) {
         this.content = content;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
     }
 }

--- a/microservices/review-service/src/main/java/shop/microservices/core/review/services/MappingUtils.java
+++ b/microservices/review-service/src/main/java/shop/microservices/core/review/services/MappingUtils.java
@@ -16,7 +16,8 @@ public final class MappingUtils {
                 review.reviewId(),
                 review.author(),
                 review.subject(),
-                review.content()
+                review.content(),
+                review.date()
         );
     }
 
@@ -27,6 +28,7 @@ public final class MappingUtils {
                 reviewEntity.getAuthor(),
                 reviewEntity.getSubject(),
                 reviewEntity.getContent(),
+                reviewEntity.getDate(),
                 null
         );
     }

--- a/microservices/review-service/src/main/resources/db/migration/V2__.sql
+++ b/microservices/review-service/src/main/resources/db/migration/V2__.sql
@@ -1,0 +1,5 @@
+ALTER TABLE reviews
+    ADD date date NULL;
+
+ALTER TABLE reviews
+    MODIFY date date NOT NULL;

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/PersistenceTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/PersistenceTests.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.microservices.core.review.persistence.ReviewEntity;
 import shop.microservices.core.review.persistence.ReviewRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,7 +37,7 @@ class PersistenceTests extends MySqlTestBase {
     void setupDb() {
         repository.deleteAll();
 
-        ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", REVIEW_CONTENT);
+        ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", REVIEW_CONTENT, LocalDate.now());
         savedEntity = repository.save(entity);
 
         assertEqualsReview(entity, savedEntity);
@@ -44,7 +45,7 @@ class PersistenceTests extends MySqlTestBase {
 
     @Test
     void create() {
-        ReviewEntity newEntity = new ReviewEntity(1, 3, "a", "s", REVIEW_CONTENT);
+        ReviewEntity newEntity = new ReviewEntity(1, 3, "a", "s", REVIEW_CONTENT, LocalDate.now());
         repository.save(newEntity);
 
         ReviewEntity foundEntity = repository.findById(newEntity.getId()).get();
@@ -80,7 +81,7 @@ class PersistenceTests extends MySqlTestBase {
     @Test
     void duplicateError() {
         assertThrows(DataIntegrityViolationException.class, () -> {
-            ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", REVIEW_CONTENT);
+            ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", REVIEW_CONTENT, LocalDate.now());
             repository.save(entity);
         });
     }

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewDbMigrationTest.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewDbMigrationTest.java
@@ -29,7 +29,7 @@ public class ReviewDbMigrationTest extends MySqlTestBase {
         BigInteger dbMajorVersion = flyway.info().current().getVersion().getMajor();
 
         assertThat(dbMajorVersion)
-                .isEqualTo(1);
+                .isEqualTo(2);
 
         try {
             //noinspection SqlDialectInspection

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApiTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApiTests.java
@@ -1,6 +1,8 @@
 package shop.microservices.core.review;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +13,9 @@ import org.springframework.test.json.AbstractJsonContentAssert;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import shop.api.core.review.Review;
 import shop.microservices.core.review.persistence.ReviewRepository;
+import shop.util.http.LocalDateConverter;
+
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -127,11 +132,11 @@ class ReviewServiceApiTests extends MySqlTestBase {
     }
 
     private AbstractJsonContentAssert<?> postAndVerifyReview(int productId, int reviewId, HttpStatus expectedStatus) {
-        Review review = new Review(productId, reviewId, "Author " + reviewId, "Subject " + reviewId, REVIEW_CONTENT + reviewId, "SA");
+        Review review = new Review(productId, reviewId, "Author " + reviewId, "Subject " + reviewId, REVIEW_CONTENT + reviewId, LocalDate.now(), "SA");
         return mockMvcTester.post()
                 .uri("/review")
                 .contentType(APPLICATION_JSON)
-                .content(new Gson().toJson(review))
+                .content(gson().toJson(review))
                 .exchange()
                 .assertThat()
                 .hasStatus(expectedStatus)
@@ -148,5 +153,11 @@ class ReviewServiceApiTests extends MySqlTestBase {
                 .assertThat()
                 .hasStatus(expectedStatus)
                 .bodyJson();
+    }
+
+    private static Gson gson() {
+        GsonBuilder builder = new GsonBuilder();
+        builder.registerTypeAdapter(new TypeToken<LocalDate>(){}.getType(), new LocalDateConverter());
+        return builder.create();
     }
 }

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(properties = {"spring.flyway.enabled: false"})
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewValidationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewValidationTests.java
@@ -5,6 +5,8 @@ import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
 import shop.microservices.core.review.persistence.ReviewEntity;
 
+import java.time.LocalDate;
+
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -16,10 +18,10 @@ public class ReviewValidationTests {
             Validator validator = validatorFactory.getValidator();
 
             var violations = validator.validate(
-                    new ReviewEntity(-1, -1, "", "", "test"));
+                    new ReviewEntity(-1, -1, "", "", "test", null));
 
             assertFalse(violations.isEmpty());
-            assertEquals(5, violations.size());
+            assertEquals(6, violations.size());
             assertThat(violations)
                     .extracting(it -> it.getPropertyPath() + " " + it.getMessage())
                     .containsExactlyInAnyOrder(
@@ -27,7 +29,8 @@ public class ReviewValidationTests {
                             "reviewId must be greater than or equal to 0",
                             "author must not be blank",
                             "content size must be between 50 and 200",
-                            "subject must not be blank");
+                            "subject must not be blank",
+                            "date must not be null");
         }
     }
 
@@ -42,7 +45,8 @@ public class ReviewValidationTests {
                             0,
                             "John Snow",
                             "Test",
-                            "Lorem ipsum dolor sit amet, consetetur sadipscingw"));
+                            "Lorem ipsum dolor sit amet, consetetur sadipscingw",
+                            LocalDate.now()));
 
             assertTrue(violations.isEmpty());
         }

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     implementation project(':api')
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'com.google.code.gson:gson:2.13.1'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/util/src/main/java/shop/util/http/LocalDateConverter.java
+++ b/util/src/main/java/shop/util/http/LocalDateConverter.java
@@ -1,0 +1,23 @@
+package shop.util.http;
+
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateConverter implements JsonSerializer<LocalDate>, JsonDeserializer<LocalDate> {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    @Override
+    public JsonElement serialize(LocalDate src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(FORMATTER.format(src));
+    }
+
+    @Override
+    public LocalDate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        return FORMATTER.parse(json.getAsString(), LocalDate::from);
+    }
+}


### PR DESCRIPTION
Review Service: store a date when a review was written.

- Add a `date` field of type `LocalDate` to both the `Review` API record and the `ReviewEntity` JPA entity.
- The field must be non-nullable.
- Update constructors, getters, setters, and mappers to include the `date` field.
- Update database schema to add `date` column with NOT NULL constraint.
- Ensure JSON serialization and deserialization support `LocalDate` in ISO format.
- Update any relevant services or utility classes to handle the `date` field correctly.