### PR TITLE
Product Composite Service: implement all CRUD operations for products

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:product-composite-service:shop.microservices.composite.product.ProductCompositeApiTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/api/src/main/java/shop/api/composite/product/ProductCompositeService.java
+++ b/api/src/main/java/shop/api/composite/product/ProductCompositeService.java
@@ -4,11 +4,31 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "ProductComposite", description = "REST API for composite product information.")
 public interface ProductCompositeService {
+
+    /**
+     * Sample usage, see below.
+     * <p>
+     * curl -X POST $HOST:$PORT/product-composite \
+     * -H "Content-Type: application/json" --data \
+     * '{"productId":123,"name":"product 123","weight":123}'
+     *
+     * @param body A JSON representation of the new composite product
+     */
+    @Operation(
+            summary = "${api.product-composite.create-composite-product.description}",
+            description = "${api.product-composite.create-composite-product.notes}")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "400", description = "${api.responseCodes.badRequest.description}"),
+            @ApiResponse(responseCode = "422", description = "${api.responseCodes.unprocessableEntity.description}")
+    })
+    @PostMapping(
+            value = "/product-composite",
+            consumes = "application/json")
+    void createProduct(@RequestBody ProductAggregate body);
 
     /**
      * Sample usage: "curl $HOST:$PORT/product-composite/1".
@@ -29,4 +49,19 @@ public interface ProductCompositeService {
             value = "/product-composite/{productId}",
             produces = "application/json")
     ProductAggregate getProduct(@PathVariable int productId);
+
+    /**
+     * Sample usage: "curl -X DELETE $HOST:$PORT/product-composite/1".
+     *
+     * @param productId ID of the product
+     */
+    @Operation(
+            summary = "${api.product-composite.delete-composite-product.description}",
+            description = "${api.product-composite.delete-composite-product.notes}")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "400", description = "${api.responseCodes.badRequest.description}"),
+            @ApiResponse(responseCode = "422", description = "${api.responseCodes.unprocessableEntity.description}")
+    })
+    @DeleteMapping(value = "/product-composite/{productId}")
+    void deleteProduct(@PathVariable int productId);
 }

--- a/microservices/product-composite-service/build.gradle
+++ b/microservices/product-composite-service/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.google.code.gson:gson:2.13.1'
 }
 
 tasks.withType(Test).configureEach {

--- a/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeServiceImpl.java
+++ b/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeServiceImpl.java
@@ -1,5 +1,7 @@
 package shop.microservices.composite.product.services;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
 import shop.api.composite.product.*;
@@ -9,11 +11,14 @@ import shop.api.core.review.Review;
 import shop.api.exceptions.InvalidInputException;
 import shop.util.http.ServiceUtil;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
 public class ProductCompositeServiceImpl implements ProductCompositeService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ProductCompositeServiceImpl.class);
 
     private final ServiceUtil serviceUtil;
     private final ProductCompositeIntegration integration;
@@ -28,7 +33,46 @@ public class ProductCompositeServiceImpl implements ProductCompositeService {
     }
 
     @Override
+    public void createProduct(ProductAggregate body) {
+        try {
+            LOG.debug("createCompositeProduct: creates a new composite entity for productId: {}", body.productId());
+
+            Product product = new Product(body.productId(), body.name(), body.weight(), null);
+            integration.createProduct(product);
+
+            if (body.recommendations() != null) {
+                body.recommendations().forEach(r -> {
+                    Recommendation recommendation = new Recommendation(
+                            body.productId(),
+                            r.recommendationId(),
+                            r.author(),
+                            r.rate(),
+                            r.content(),
+                            null);
+                    integration.createRecommendation(recommendation);
+                });
+            }
+
+            if (body.reviews() != null) {
+                body.reviews().forEach(r -> {
+                    Review review = new Review(body.productId(), r.reviewId(), r.author(), r.subject(), r.content(), LocalDate.now(), null);
+                    integration.createReview(review);
+                });
+            }
+
+            LOG.debug("createCompositeProduct: composite entities created for productId: {}", body.productId());
+
+        } catch (RuntimeException re) {
+            LOG.warn("createCompositeProduct failed", re);
+            throw re;
+        }
+    }
+
+
+    @Override
     public ProductAggregate getProduct(int productId) {
+        LOG.debug("getCompositeProduct: lookup a product aggregate for productId: {}", productId);
+
         Product product = integration.getProduct(productId);
         if (product == null) {
             throw new InvalidInputException("No product found for productId: " + productId);
@@ -38,7 +82,22 @@ public class ProductCompositeServiceImpl implements ProductCompositeService {
 
         List<Review> reviews = integration.getReviews(productId);
 
+        LOG.debug("getCompositeProduct: aggregate entity found for productId: {}", productId);
+
         return createProductAggregate(product, recommendations, reviews, serviceUtil.getServiceAddress());
+    }
+
+    @Override
+    public void deleteProduct(int productId) {
+        LOG.debug("deleteCompositeProduct: Deletes a product aggregate for productId: {}", productId);
+
+        integration.deleteProduct(productId);
+
+        integration.deleteRecommendations(productId);
+
+        integration.deleteReviews(productId);
+
+        LOG.debug("deleteCompositeProduct: aggregate entities deleted for productId: {}", productId);
     }
 
     private ProductAggregate createProductAggregate(
@@ -53,13 +112,17 @@ public class ProductCompositeServiceImpl implements ProductCompositeService {
 
         // 2. Copy summary recommendation info, if available
         List<RecommendationSummary> recommendationSummaries =
-                (recommendations == null) ? null : recommendations.stream()
+                (recommendations == null)
+                        ? null
+                        : recommendations.stream()
                         .map(r -> new RecommendationSummary(r.recommendationId(), r.author(), r.rate(), r.content()))
                         .collect(Collectors.toList());
 
         // 3. Copy summary review info, if available
         List<ReviewSummary> reviewSummaries =
-                (reviews == null) ? null : reviews.stream()
+                (reviews == null)
+                        ? null
+                        : reviews.stream()
                         .map(r -> new ReviewSummary(r.reviewId(), r.author(), r.subject(), r.content()))
                         .collect(Collectors.toList());
 

--- a/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
+++ b/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
@@ -1,12 +1,18 @@
 package shop.microservices.composite.product;
 
+import com.google.gson.Gson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.AbstractJsonContentAssert;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import shop.api.composite.product.ProductAggregate;
+import shop.api.composite.product.RecommendationSummary;
+import shop.api.composite.product.ReviewSummary;
 import shop.api.core.product.Product;
 import shop.api.core.recommendation.Recommendation;
 import shop.api.core.review.Review;
@@ -17,14 +23,17 @@ import java.time.LocalDate;
 
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
-@WebMvcTest
-public class ProductCompositeApiTests {
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class ProductCompositeApiTests {
 
     private static final int PRODUCT_ID_OK = 1;
-    private static final int PRODUCT_ID_INVALID = -1;
+    private static final int PRODUCT_ID_INVALID = 3;
 
     @Autowired
     private MockMvcTester mockMvcTester;
@@ -36,59 +45,83 @@ public class ProductCompositeApiTests {
     void setUp() {
         when(compositeIntegration.getProduct(PRODUCT_ID_OK))
                 .thenReturn(new Product(PRODUCT_ID_OK, "name", 1, "mock-address"));
-        when(compositeIntegration.getProduct(PRODUCT_ID_INVALID))
-                .thenThrow(new InvalidInputException("INVALID: " + PRODUCT_ID_INVALID));
-
         when(compositeIntegration.getRecommendations(PRODUCT_ID_OK))
                 .thenReturn(singletonList(new Recommendation(PRODUCT_ID_OK, 1, "author", 1, "content", "mock address")));
-
         when(compositeIntegration.getReviews(PRODUCT_ID_OK))
                 .thenReturn(singletonList(new Review(PRODUCT_ID_OK, 1, "author", "subject", "content", LocalDate.now(), "mock address")));
+        when(compositeIntegration.getProduct(PRODUCT_ID_INVALID))
+                .thenThrow(new InvalidInputException("INVALID: " + PRODUCT_ID_INVALID));
     }
 
     @Test
-    public void testProductCompositeServiceApi() {
-        var jsonBody = mockMvcTester.get()
-                .uri("/product-composite/" + PRODUCT_ID_OK)
+    void createCompositeProduct1() {
+        ProductAggregate compositeProduct = new ProductAggregate(1, "name", 1, null, null, null);
+
+        postAndVerifyProduct(compositeProduct, OK);
+    }
+
+    @Test
+    void createCompositeProduct2() {
+        ProductAggregate compositeProduct = new ProductAggregate(1, "name", 1,
+                singletonList(new RecommendationSummary(1, "a", 1, "c")),
+                singletonList(new ReviewSummary(1, "a", "s", "c")), null);
+
+        postAndVerifyProduct(compositeProduct, OK);
+    }
+
+    @Test
+    void deleteCompositeProduct() {
+        ProductAggregate compositeProduct = new ProductAggregate(1, "name", 1,
+                singletonList(new RecommendationSummary(1, "a", 1, "c")),
+                singletonList(new ReviewSummary(1, "a", "s", "c")), null);
+
+        postAndVerifyProduct(compositeProduct, OK);
+
+        deleteAndVerifyProduct(compositeProduct.productId(), OK);
+        deleteAndVerifyProduct(compositeProduct.productId(), OK);
+    }
+
+    @Test
+    void getProductById() {
+        getAndVerifyProduct(PRODUCT_ID_OK, OK)
+                .hasPathSatisfying("$.productId", it -> it.assertThat().isEqualTo(PRODUCT_ID_OK))
+                .hasPathSatisfying("$.recommendations.length()", it -> it.assertThat().isEqualTo(1))
+                .hasPathSatisfying("$.reviews.length()", it -> it.assertThat().isEqualTo(1));
+    }
+
+    @Test
+    void getProductInvalidInput() {
+        getAndVerifyProduct(PRODUCT_ID_INVALID, UNPROCESSABLE_ENTITY);
+    }
+
+    private AbstractJsonContentAssert<?> getAndVerifyProduct(int productId, HttpStatus expectedStatus) {
+        return mockMvcTester.get()
+                .uri("/product-composite/" + productId)
                 .accept(APPLICATION_JSON)
                 .exchange()
                 .assertThat()
-                .hasStatus(OK)
-                .hasContentType(APPLICATION_JSON)
+                .hasStatus(expectedStatus)
                 .bodyJson();
-
-        jsonBody.extractingPath("$.productId").isEqualTo(PRODUCT_ID_OK);
-        jsonBody.extractingPath("$.name").isEqualTo("name");
-        jsonBody.extractingPath("$.weight").isEqualTo(1);
-
-        jsonBody.extractingPath("$.recommendations[0].recommendationId").isEqualTo(1);
-        jsonBody.extractingPath("$.recommendations[0].author").isEqualTo("author");
-        jsonBody.extractingPath("$.recommendations[0].rate").isEqualTo(1);
-        jsonBody.extractingPath("$.recommendations[0].content").isEqualTo("content");
-
-        jsonBody.extractingPath("$.reviews[0].reviewId").isEqualTo(1);
-        jsonBody.extractingPath("$.reviews[0].author").isEqualTo("author");
-        jsonBody.extractingPath("$.reviews[0].subject").isEqualTo("subject");
-        jsonBody.extractingPath("$.reviews[0].content").isEqualTo("content");
     }
 
-    @Test
-    void testBadRequestForWrongParameterType() {
-        mockMvcTester.get()
-                .uri("/product-composite/no-integer")
-                .accept(APPLICATION_JSON)
+    @SuppressWarnings("SameParameterValue")
+    private void postAndVerifyProduct(ProductAggregate compositeProduct, HttpStatus expectedStatus) {
+        mockMvcTester.post()
+                .uri("/product-composite")
+                .contentType(APPLICATION_JSON)
+                .content(new Gson().toJson(compositeProduct))
                 .exchange()
                 .assertThat()
-                .hasStatus(HttpStatus.BAD_REQUEST);
+                .hasStatus(expectedStatus);
     }
 
-    @Test
-    void testUnprocessableEntityForNegativeParameter() {
-        mockMvcTester.get()
-                .uri("/product-composite/" + PRODUCT_ID_INVALID)
-                .accept(APPLICATION_JSON)
+    @SuppressWarnings("SameParameterValue")
+    private void deleteAndVerifyProduct(int productId, HttpStatus expectedStatus) {
+        mockMvcTester.delete()
+                .uri("/product-composite/" + productId)
+                .contentType(APPLICATION_JSON)
                 .exchange()
                 .assertThat()
-                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY);
+                .hasStatus(expectedStatus);
     }
 }

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApiTests.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApiTests.java
@@ -19,7 +19,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @AutoConfigureMockMvc
 @SpringBootTest
-public class ProductServiceApiTests {
+public class ProductServiceApiTests extends PostgresTestBase {
 
     @Autowired
     private MockMvcTester mockMvcTester;

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class ProductServiceApplicationTests {
+public class ProductServiceApplicationTests extends PostgresTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class RecommendationServiceApplicationTests {
+public class RecommendationServiceApplicationTests extends MongoDbTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(properties = {"spring.flyway.enabled: false"})
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;


### PR DESCRIPTION
- Implement CRUD operations for composite products in `ProductCompositeService`
- Add new endpoints with OpenAPI documentation: POST, DELETE for composite products
- Enhance service layer with integration methods
- Refactor product, recommendations, and reviews retrieval logic
- Update tests with comprehensive cases for new operations