### PR TITLE
Properly handle cases when a product is missing by the given ID

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:product-composite-service:shop.microservices.composite.product.ProductCompositeApiTests#getProductNotFound"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/api/src/main/java/shop/api/exceptions/NotFoundException.java
+++ b/api/src/main/java/shop/api/exceptions/NotFoundException.java
@@ -1,0 +1,19 @@
+package shop.api.exceptions;
+
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException() {
+    }
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+
+    public NotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotFoundException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeIntegration.java
+++ b/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeIntegration.java
@@ -24,6 +24,7 @@ import shop.api.core.review.Review;
 import shop.api.core.review.ReviewService;
 import shop.api.event.Event;
 import shop.api.exceptions.InvalidInputException;
+import shop.api.exceptions.NotFoundException;
 import shop.util.http.HttpErrorInfo;
 
 import java.io.IOException;
@@ -182,6 +183,7 @@ public class ProductCompositeIntegration implements ProductService, Recommendati
 
         switch (HttpStatus.resolve(responseException.getStatusCode().value())) {
             case NOT_FOUND:
+                return new NotFoundException(getErrorMessage(responseException));
             case UNPROCESSABLE_ENTITY:
                 return new InvalidInputException(getErrorMessage(responseException));
             case null:

--- a/microservices/product-service/src/main/java/shop/microservices/core/product/services/ProductServiceImpl.java
+++ b/microservices/product-service/src/main/java/shop/microservices/core/product/services/ProductServiceImpl.java
@@ -7,6 +7,7 @@ import reactor.core.publisher.Mono;
 import shop.api.core.product.Product;
 import shop.api.core.product.ProductService;
 import shop.api.exceptions.InvalidInputException;
+import shop.api.exceptions.NotFoundException;
 import shop.microservices.core.product.persistence.ProductEntity;
 import shop.microservices.core.product.persistence.ProductRepository;
 import shop.util.http.ServiceUtil;
@@ -51,6 +52,7 @@ public class ProductServiceImpl implements ProductService {
         }
 
         return repository.findByProductId(productId)
+                .switchIfEmpty(Mono.error(new NotFoundException("No product found for productId: " + productId)))
                 .map(mapper::entityToApi)
                 .map(e -> e.withServiceAddress(serviceUtil.getServiceAddress()));
     }

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductMigrationTest.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductMigrationTest.java
@@ -1,45 +1,15 @@
 package shop.microservices.core.product;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.r2dbc.core.DatabaseClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
 
 @SpringBootTest
-public class ProductMigrationTest {
-
-    private static final JdbcDatabaseContainer<?> database =
-            new PostgreSQLContainer<>("postgres:17.5")
-                    .withStartupTimeoutSeconds(300)
-                    .withDatabaseName("product-db")
-                    .withUsername("user")
-                    .withPassword("pwd");
+public class ProductMigrationTest extends PostgresTestBase {
 
     @Autowired
     private DatabaseClient dbClient;
-
-    @BeforeAll
-    public static void startDb() {
-        database.start();
-    }
-
-    @AfterAll
-    public static void stopDb() {
-        database.stop();
-    }
-
-    @DynamicPropertySource
-    static void databaseProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", database::getJdbcUrl);
-        registry.add("spring.datasource.username", database::getUsername);
-        registry.add("spring.datasource.password", database::getPassword);
-    }
 
     @SuppressWarnings("ReactiveStreamsUnusedPublisher")
     @Test

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class ProductServiceApplicationTests {
+public class ProductServiceApplicationTests extends PostgresTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class RecommendationServiceApplicationTests {
+public class RecommendationServiceApplicationTests extends MongoDbTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
         "spring.flyway.enabled: false",
         "eureka.client.enabled=false"
 })
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;

--- a/util/src/main/java/shop/util/http/GlobalControllerExceptionHandler.java
+++ b/util/src/main/java/shop/util/http/GlobalControllerExceptionHandler.java
@@ -9,7 +9,9 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import shop.api.exceptions.InvalidInputException;
+import shop.api.exceptions.NotFoundException;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 @RestControllerAdvice
@@ -17,6 +19,13 @@ class GlobalControllerExceptionHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(GlobalControllerExceptionHandler.class);
 
+    @ResponseStatus(NOT_FOUND)
+    @ExceptionHandler(NotFoundException.class)
+    public @ResponseBody HttpErrorInfo handleNotFoundExceptions(
+            ServerHttpRequest request, NotFoundException ex) {
+
+        return createHttpErrorInfo(NOT_FOUND, request, ex);
+    }
 
     @ResponseStatus(UNPROCESSABLE_ENTITY)
     @ExceptionHandler(InvalidInputException.class)


### PR DESCRIPTION
Properly handle cases when a product is missing by the given ID.
When a requested product is not found, return a JSON response with HTTP status 404 Not Found.
The JSON must include an error message field describing the problem. Implement a custom exception NotFoundException and handle it in the global exception handler so that all requests for missing products return the same JSON structure.