### PR TITLE
Introduce the 'rating' field for reviews

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,17 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:product-composite-service:shop.microservices.composite.product.MessagingTests#createCompositeProduct2",
+      "microservices:product-composite-service:shop.microservices.composite.product.ProductCompositeApiTests#getProductById",
+      "microservices:review-service:shop.microservices.core.review.PersistenceTests#getByProductId",
+      "microservices:review-service:shop.microservices.core.review.ReviewDbMigrationTest#testMigration",
+      "microservices:review-service:shop.microservices.core.review.ReviewMapperTest#mapperTests",
+      "microservices:review-service:shop.microservices.core.review.ReviewMapperTest#mapperListTests",
+      "microservices:review-service:shop.microservices.core.review.ReviewServiceApiTests#getReviewsByProductId",
+      "microservices:review-service:shop.microservices.core.review.ReviewValidationTests#testReviewEntityValidationNegative",
+      "microservices:review-service:shop.microservices.core.review.ReviewValidationTests#testReviewEntityValidationPositive"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/api/src/main/java/shop/api/composite/product/ReviewSummary.java
+++ b/api/src/main/java/shop/api/composite/product/ReviewSummary.java
@@ -4,6 +4,7 @@ public record ReviewSummary(
         int reviewId,
         String author,
         String subject,
-        String content
+        String content,
+        int rating
 ) {
 }

--- a/api/src/main/java/shop/api/core/review/Review.java
+++ b/api/src/main/java/shop/api/core/review/Review.java
@@ -8,10 +8,11 @@ public record Review(
         String author,
         String subject,
         String content,
+        int rating,
         LocalDate date,
         String serviceAddress
 ) {
     public Review withServiceAddress(String serviceAddress) {
-        return new Review(productId, reviewId, author, subject, content, date, serviceAddress);
+        return new Review(productId, reviewId, author, subject, content, rating, date, serviceAddress);
     }
 }

--- a/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeServiceImpl.java
+++ b/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeServiceImpl.java
@@ -58,7 +58,7 @@ public class ProductCompositeServiceImpl implements ProductCompositeService {
 
             if (body.reviews() != null) {
                 body.reviews().forEach(r -> {
-                    Review review = new Review(body.productId(), r.reviewId(), r.author(), r.subject(), r.content(), LocalDate.now(), null);
+                    Review review = new Review(body.productId(), r.reviewId(), r.author(), r.subject(), r.content(), r.rating(), LocalDate.now(), null);
                     monoList.add(integration.createReview(review));
                 });
             }
@@ -118,7 +118,7 @@ public class ProductCompositeServiceImpl implements ProductCompositeService {
                 (reviews == null)
                         ? null
                         : reviews.stream()
-                        .map(r -> new ReviewSummary(r.reviewId(), r.author(), r.subject(), r.content()))
+                        .map(r -> new ReviewSummary(r.reviewId(), r.author(), r.subject(), r.content(), r.rating()))
                         .collect(Collectors.toList());
 
         // 4. Create info regarding the involved microservices addresses

--- a/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/MessagingTests.java
+++ b/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/MessagingTests.java
@@ -84,7 +84,7 @@ class MessagingTests {
     void createCompositeProduct2() {
         ProductAggregate composite = new ProductAggregate(1, "name", 1,
                 singletonList(new RecommendationSummary(1, "a", 1, "c")),
-                singletonList(new ReviewSummary(1, "a", "s", "c")), null);
+                singletonList(new ReviewSummary(1, "a", "s", "c", 4)), null);
         postAndVerifyProduct(composite, ACCEPTED);
 
         final List<String> productMessages = getMessages("products");
@@ -112,7 +112,7 @@ class MessagingTests {
 
         ReviewSummary rev = composite.reviews().getFirst();
         Event<Integer, Product> expectedReviewEvent =
-                new Event(CREATE, composite.productId(), new Review(composite.productId(), rev.reviewId(), rev.author(), rev.subject(), rev.content(), LocalDate.now(), null));
+                new Event(CREATE, composite.productId(), new Review(composite.productId(), rev.reviewId(), rev.author(), rev.subject(), rev.content(), rev.rating(), LocalDate.now(), null));
         assertThat(reviewMessages.getFirst(), is(sameEventExceptCreatedAt(expectedReviewEvent)));
     }
 

--- a/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
+++ b/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
@@ -45,7 +45,7 @@ class ProductCompositeApiTests {
         when(compositeIntegration.getRecommendations(PRODUCT_ID_OK))
                 .thenReturn(Flux.just(new Recommendation(PRODUCT_ID_OK, 1, "author", 1, "content", "mock address")));
         when(compositeIntegration.getReviews(PRODUCT_ID_OK))
-                .thenReturn(Flux.just(new Review(PRODUCT_ID_OK, 1, "author", "subject", "content", LocalDate.now(), "mock address")));
+                .thenReturn(Flux.just(new Review(PRODUCT_ID_OK, 1, "author", "subject", "content", 4, LocalDate.now(), "mock address")));
         when(compositeIntegration.getProduct(PRODUCT_ID_INVALID))
                 .thenThrow(new InvalidInputException("INVALID: " + PRODUCT_ID_INVALID));
         when(compositeIntegration.getProduct(PRODUCT_ID_NOT_FOUND))

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductMigrationTest.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductMigrationTest.java
@@ -1,45 +1,15 @@
 package shop.microservices.core.product;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.r2dbc.core.DatabaseClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
 
 @SpringBootTest
-public class ProductMigrationTest {
-
-    private static final JdbcDatabaseContainer<?> database =
-            new PostgreSQLContainer<>("postgres:17.5")
-                    .withStartupTimeoutSeconds(300)
-                    .withDatabaseName("product-db")
-                    .withUsername("user")
-                    .withPassword("pwd");
+public class ProductMigrationTest extends PostgresTestBase {
 
     @Autowired
     private DatabaseClient dbClient;
-
-    @BeforeAll
-    public static void startDb() {
-        database.start();
-    }
-
-    @AfterAll
-    public static void stopDb() {
-        database.stop();
-    }
-
-    @DynamicPropertySource
-    static void databaseProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", database::getJdbcUrl);
-        registry.add("spring.datasource.username", database::getUsername);
-        registry.add("spring.datasource.password", database::getPassword);
-    }
 
     @SuppressWarnings("ReactiveStreamsUnusedPublisher")
     @Test

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class ProductServiceApplicationTests {
+public class ProductServiceApplicationTests extends PostgresTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class RecommendationServiceApplicationTests {
+public class RecommendationServiceApplicationTests extends MongoDbTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/review-service/src/main/java/shop/microservices/core/review/persistence/ReviewEntity.java
+++ b/microservices/review-service/src/main/java/shop/microservices/core/review/persistence/ReviewEntity.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.Range;
 
 import java.time.LocalDate;
 
@@ -31,18 +32,21 @@ public class ReviewEntity {
     private String subject;
     @Size(min = 50, max = 200)
     private String content;
+    @Range(min = 1, max = 5)
+    private int rating;
     @NotNull
     private LocalDate date;
 
     public ReviewEntity() {
     }
 
-    public ReviewEntity(int productId, int reviewId, String author, String subject, String content, LocalDate date) {
+    public ReviewEntity(int productId, int reviewId, String author, String subject, String content, int rating, LocalDate date) {
         this.productId = productId;
         this.reviewId = reviewId;
         this.author = author;
         this.subject = subject;
         this.content = content;
+        this.rating = rating;
         this.date = date;
     }
 
@@ -100,6 +104,14 @@ public class ReviewEntity {
 
     public void setContent(String content) {
         this.content = content;
+    }
+
+    public int getRating() {
+        return rating;
+    }
+
+    public void setRating(int rating) {
+        this.rating = rating;
     }
 
     public LocalDate getDate() {

--- a/microservices/review-service/src/main/resources/db/migration/V3__.sql
+++ b/microservices/review-service/src/main/resources/db/migration/V3__.sql
@@ -1,0 +1,5 @@
+ALTER TABLE reviews
+    ADD rating INT NULL;
+
+ALTER TABLE reviews
+    MODIFY rating INT NOT NULL;

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/PersistenceTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/PersistenceTests.java
@@ -37,7 +37,7 @@ class PersistenceTests extends MySqlTestBase {
     void setupDb() {
         repository.deleteAll();
 
-        ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", REVIEW_CONTENT, LocalDate.now());
+        ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", REVIEW_CONTENT, 4, LocalDate.now());
         savedEntity = repository.save(entity);
 
         assertEqualsReview(entity, savedEntity);
@@ -45,7 +45,7 @@ class PersistenceTests extends MySqlTestBase {
 
     @Test
     void create() {
-        ReviewEntity newEntity = new ReviewEntity(1, 3, "a", "s", REVIEW_CONTENT, LocalDate.now());
+        ReviewEntity newEntity = new ReviewEntity(1, 3, "a", "s", REVIEW_CONTENT, 4, LocalDate.now());
         repository.save(newEntity);
 
         ReviewEntity foundEntity = repository.findById(newEntity.getId()).get();
@@ -81,7 +81,7 @@ class PersistenceTests extends MySqlTestBase {
     @Test
     void duplicateError() {
         assertThrows(DataIntegrityViolationException.class, () -> {
-            ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", REVIEW_CONTENT, LocalDate.now());
+            ReviewEntity entity = new ReviewEntity(1, 2, "a", "s", REVIEW_CONTENT, 4, LocalDate.now());
             repository.save(entity);
         });
     }

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewDbMigrationTest.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewDbMigrationTest.java
@@ -29,7 +29,7 @@ public class ReviewDbMigrationTest extends MySqlTestBase {
         BigInteger dbMajorVersion = flyway.info().current().getVersion().getMajor();
 
         assertThat(dbMajorVersion)
-                .isEqualTo(2);
+                .isEqualTo(3);
 
         try {
             //noinspection SqlDialectInspection

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewMapperTest.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewMapperTest.java
@@ -20,7 +20,7 @@ class ReviewMapperTest {
     void mapperTests() {
         assertNotNull(mapper);
 
-        Review api = new Review(1, 2, "a", "s", "C", LocalDate.now(), "adr");
+        Review api = new Review(1, 2, "a", "s", "C", 4, LocalDate.now(), "adr");
 
         ReviewEntity entity = mapper.apiToEntity(api);
 
@@ -46,7 +46,7 @@ class ReviewMapperTest {
     void mapperListTests() {
         assertNotNull(mapper);
 
-        Review api = new Review(1, 2, "a", "s", "C", LocalDate.now(), "adr");
+        Review api = new Review(1, 2, "a", "s", "C", 4, LocalDate.now(), "adr");
         List<Review> apiList = Collections.singletonList(api);
 
         List<ReviewEntity> entityList = mapper.apiListToEntityList(apiList);

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApiTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApiTests.java
@@ -142,7 +142,7 @@ class ReviewServiceApiTests extends MySqlTestBase {
     }
 
     private void sendCreateReviewEvent(int productId, int reviewId) {
-        Review review = new Review(productId, reviewId, "Author " + reviewId, "Subject " + reviewId, REVIEW_CONTENT + reviewId, LocalDate.now(), "SA");
+        Review review = new Review(productId, reviewId, "Author " + reviewId, "Subject " + reviewId, REVIEW_CONTENT + reviewId, 4, LocalDate.now(), "SA");
         Event<Integer, Review> event = new Event<>(CREATE, productId, review);
         messageProcessor.accept(event);
     }

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
         "spring.flyway.enabled: false",
         "eureka.client.enabled=false"
 })
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewValidationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewValidationTests.java
@@ -18,10 +18,10 @@ public class ReviewValidationTests {
             Validator validator = validatorFactory.getValidator();
 
             var violations = validator.validate(
-                    new ReviewEntity(-1, -1, "", "", "test", null));
+                    new ReviewEntity(-1, -1, "", "", "test", -1, null));
 
             assertFalse(violations.isEmpty());
-            assertEquals(6, violations.size());
+            assertEquals(7, violations.size());
             assertThat(violations)
                     .extracting(it -> it.getPropertyPath() + " " + it.getMessage())
                     .containsExactlyInAnyOrder(
@@ -30,7 +30,8 @@ public class ReviewValidationTests {
                             "author must not be blank",
                             "content size must be between 50 and 200",
                             "subject must not be blank",
-                            "date must not be null");
+                            "date must not be null",
+                            "rating must be between 1 and 5");
         }
     }
 
@@ -46,6 +47,7 @@ public class ReviewValidationTests {
                             "John Snow",
                             "Test",
                             "Lorem ipsum dolor sit amet, consetetur sadipscingw",
+                            4,
                             LocalDate.now()));
 
             assertTrue(violations.isEmpty());


### PR DESCRIPTION
Introduce the 'rating' field for reviews 
- Update the Review DTOs:
   - Add field `rating` of type `int` to `Review` and `ReviewSummary`.
   - Ensure constructors, getters/setters (or record fields) include `rating`.
- Update the Review entity:
   - Add field `rating` of type `int` with validation: min=1, max=5.
   - Update constructors, getters, and setters to handle `rating`.
- Update services:
   - When creating Review and ReviewSummary objects in ProductCompositeServiceImpl, include the new `rating` field.
- Generate database migration scripts:
   - Add a new column 'rating' INT NOT NULL to the 'reviews' table
   - Ensure existing records are handled correctly