### PR TITLE
Support an ability to get all reviews by a product

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:product-composite-service:shop.microservices.composite.product.ProductCompositeApiTests#getReviewsByProductId"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/api/src/main/java/shop/api/composite/product/ProductCompositeService.java
+++ b/api/src/main/java/shop/api/composite/product/ProductCompositeService.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Tag(name = "ProductComposite", description = "REST API for composite product information.")
@@ -68,4 +69,19 @@ public interface ProductCompositeService {
     @ResponseStatus(HttpStatus.ACCEPTED)
     @DeleteMapping(value = "/product-composite/{productId}")
     Mono<Void> deleteProduct(@PathVariable int productId);
+
+    /**
+     * Sample usage: "curl $HOST:$PORT/product-composite/reviews/1".
+     *
+     * @param productId ID of the product
+     * @return the list of reviews for a product
+     */
+    @Operation(
+            summary = "${api.product-composite.get-reviews.description}",
+            description = "${api.product-composite.get-reviews.notes}")
+    @GetMapping(
+            value = "/product-composite/reviews/{productId}",
+            produces = "application/json"
+    )
+    Flux<ReviewSummary> getReviews(@PathVariable int productId);
 }

--- a/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeServiceImpl.java
+++ b/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeServiceImpl.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import shop.api.composite.product.*;
 import shop.api.core.product.Product;
@@ -152,5 +153,11 @@ public class ProductCompositeServiceImpl implements ProductCompositeService {
             LOG.warn("deleteCompositeProduct failed: {}", re.toString());
             throw re;
         }
+    }
+
+    @Override
+    public Flux<ReviewSummary> getReviews(int productId) {
+        return integration.getReviews(productId)
+                .map(r -> new ReviewSummary(r.reviewId(), r.author(), r.subject(), r.content(), r.rating()));
     }
 }

--- a/microservices/product-composite-service/src/main/resources/openapi-config.yml
+++ b/microservices/product-composite-service/src/main/resources/openapi-config.yml
@@ -27,6 +27,12 @@ api:
     unprocessableEntity.description: Unprocessable entity, input parameters caused the processing to fail. See response message for more information
 
   product-composite:
+    get-reviews:
+      description: Returns reviews for a specified product id
+      notes: |
+        # Normal response
+        If the requested product id is found the method will return information regarding:
+         1. Reviews
     get-composite-product:
       description: Returns a composite view of the specified product id
       notes: |

--- a/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
+++ b/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
@@ -72,6 +72,19 @@ class ProductCompositeApiTests {
                 .jsonPath("$.message").isEqualTo("NOT FOUND: " + PRODUCT_ID_NOT_FOUND);
     }
 
+    @Test
+    void getReviewsByProductId() {
+        client.get()
+                .uri("/product-composite/reviews/" + PRODUCT_ID_OK)
+                .accept(APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(OK)
+                .expectHeader().contentType(APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.length()").isEqualTo(1)
+                .jsonPath("$[0].rating").isEqualTo(4);
+    }
+
     private WebTestClient.BodyContentSpec getAndVerifyProduct(int productId, HttpStatus expectedStatus) {
         return client.get()
                 .uri("/product-composite/" + productId)

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductMigrationTest.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductMigrationTest.java
@@ -1,45 +1,15 @@
 package shop.microservices.core.product;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.r2dbc.core.DatabaseClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
 
 @SpringBootTest
-public class ProductMigrationTest {
-
-    private static final JdbcDatabaseContainer<?> database =
-            new PostgreSQLContainer<>("postgres:17.5")
-                    .withStartupTimeoutSeconds(300)
-                    .withDatabaseName("product-db")
-                    .withUsername("user")
-                    .withPassword("pwd");
+public class ProductMigrationTest extends PostgresTestBase {
 
     @Autowired
     private DatabaseClient dbClient;
-
-    @BeforeAll
-    public static void startDb() {
-        database.start();
-    }
-
-    @AfterAll
-    public static void stopDb() {
-        database.stop();
-    }
-
-    @DynamicPropertySource
-    static void databaseProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", database::getJdbcUrl);
-        registry.add("spring.datasource.username", database::getUsername);
-        registry.add("spring.datasource.password", database::getPassword);
-    }
 
     @SuppressWarnings("ReactiveStreamsUnusedPublisher")
     @Test

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class ProductServiceApplicationTests {
+public class ProductServiceApplicationTests extends PostgresTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class RecommendationServiceApplicationTests {
+public class RecommendationServiceApplicationTests extends MongoDbTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
         "spring.flyway.enabled: false",
         "eureka.client.enabled=false"
 })
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;


### PR DESCRIPTION
Support an ability to get all reviews by a product  
Add a new endpoint /product-composite/reviews/{productId} that returns a list of reviews (reviewId, author, subject, content, rating). Fetch reviews from the existing integration layer, return an empty list if none exist, update OpenAPI documentation accordingly, and include tests for both existing and empty reviews.