### PR TITLE
Add an endpoint to get all products

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:product-composite-service:shop.microservices.composite.product.ProductCompositeApiTests#getAllProducts"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/api/src/main/java/shop/api/composite/product/ProductCompositeService.java
+++ b/api/src/main/java/shop/api/composite/product/ProductCompositeService.java
@@ -54,6 +54,12 @@ public interface ProductCompositeService {
             produces = "application/json")
     Mono<ProductAggregate> getProduct(@PathVariable int productId);
 
+    @GetMapping(
+            value = "/product-composite",
+            produces = "application/json"
+    )
+    Flux<ProductAggregate> getAllProducts();
+
     /**
      * Sample usage: "curl -X DELETE $HOST:$PORT/product-composite/1".
      *

--- a/api/src/main/java/shop/api/core/product/ProductService.java
+++ b/api/src/main/java/shop/api/core/product/ProductService.java
@@ -2,6 +2,7 @@ package shop.api.core.product;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface ProductService {
@@ -20,4 +21,9 @@ public interface ProductService {
             value = "/product/{productId}",
             produces = "application/json")
     Mono<Product> getProduct(@PathVariable("productId") int productId);
+
+    @GetMapping(
+            value = "/product",
+            produces = "application/json")
+    Flux<Product> getAllProducts();
 }

--- a/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeServiceImpl.java
+++ b/microservices/product-composite-service/src/main/java/shop/microservices/composite/product/services/ProductCompositeServiceImpl.java
@@ -96,6 +96,20 @@ public class ProductCompositeServiceImpl implements ProductCompositeService {
                 .log(LOG.getName(), FINE);
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public Flux<ProductAggregate> getAllProducts() {
+        return integration.getAllProducts().flatMap(p -> Mono.zip(
+                values ->
+                        createProductAggregate(
+                                p,
+                                (List<Recommendation>) values[0],
+                                (List<Review>) values[1],
+                                serviceUtil.getServiceAddress()),
+                integration.getRecommendations(p.productId()).collectList(),
+                integration.getReviews(p.productId()).collectList()));
+    }
+
     private ProductAggregate createProductAggregate(
             Product product,
             List<Recommendation> recommendations,

--- a/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
+++ b/microservices/product-composite-service/src/test/java/shop/microservices/composite/product/ProductCompositeApiTests.java
@@ -50,6 +50,23 @@ class ProductCompositeApiTests {
                 .thenThrow(new InvalidInputException("INVALID: " + PRODUCT_ID_INVALID));
         when(compositeIntegration.getProduct(PRODUCT_ID_NOT_FOUND))
                 .thenThrow(new NotFoundException("NOT FOUND: " + PRODUCT_ID_NOT_FOUND));
+
+        when(compositeIntegration.getAllProducts())
+                .thenReturn(Flux.just(
+                        new Product(5, "water", 1, "mock-address"),
+                        new Product(6, "bread", 2, "mock-address"),
+                        new Product(7, "sugar", 3, "mock-address")));
+        when(compositeIntegration.getRecommendations(5))
+                .thenReturn(Flux.just(
+                        new Recommendation(5, 5, "author", 5, "content", "mock address")
+                ));
+        when(compositeIntegration.getRecommendations(6)).thenReturn(Flux.just());
+        when(compositeIntegration.getRecommendations(7)).thenReturn(Flux.just());
+        when(compositeIntegration.getReviews(5)).thenReturn(Flux.just(
+                new Review(5, 5, "author", "subject", "content", 5, LocalDate.now(), "mock address")
+        ));
+        when(compositeIntegration.getReviews(6)).thenReturn(Flux.just());
+        when(compositeIntegration.getReviews(7)).thenReturn(Flux.just());
     }
 
     @Test
@@ -83,6 +100,23 @@ class ProductCompositeApiTests {
                 .expectBody()
                 .jsonPath("$.length()").isEqualTo(1)
                 .jsonPath("$[0].rating").isEqualTo(4);
+    }
+
+    @Test
+    void getAllProducts() {
+        client.get()
+                .uri("/product-composite")
+                .accept(APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(OK)
+                .expectHeader().contentType(APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.length()").isEqualTo(3)
+                .jsonPath("$[0].name").isEqualTo("water")
+                .jsonPath("$[0].recommendations[0].author").isEqualTo("author")
+                .jsonPath("$[0].reviews[0].author").isEqualTo("author")
+                .jsonPath("$[1].name").isEqualTo("bread")
+                .jsonPath("$[2].name").isEqualTo("sugar");
     }
 
     private WebTestClient.BodyContentSpec getAndVerifyProduct(int productId, HttpStatus expectedStatus) {

--- a/microservices/product-service/src/main/java/shop/microservices/core/product/services/ProductServiceImpl.java
+++ b/microservices/product-service/src/main/java/shop/microservices/core/product/services/ProductServiceImpl.java
@@ -3,6 +3,7 @@ package shop.microservices.core.product.services;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import shop.api.core.product.Product;
 import shop.api.core.product.ProductService;
@@ -53,6 +54,13 @@ public class ProductServiceImpl implements ProductService {
 
         return repository.findByProductId(productId)
                 .switchIfEmpty(Mono.error(new NotFoundException("No product found for productId: " + productId)))
+                .map(mapper::entityToApi)
+                .map(e -> e.withServiceAddress(serviceUtil.getServiceAddress()));
+    }
+
+    @Override
+    public Flux<Product> getAllProducts() {
+        return repository.findAll()
                 .map(mapper::entityToApi)
                 .map(e -> e.withServiceAddress(serviceUtil.getServiceAddress()));
     }

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductMigrationTest.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductMigrationTest.java
@@ -1,45 +1,15 @@
 package shop.microservices.core.product;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.r2dbc.core.DatabaseClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
 
 @SpringBootTest
-public class ProductMigrationTest {
-
-    private static final JdbcDatabaseContainer<?> database =
-            new PostgreSQLContainer<>("postgres:17.5")
-                    .withStartupTimeoutSeconds(300)
-                    .withDatabaseName("product-db")
-                    .withUsername("user")
-                    .withPassword("pwd");
+public class ProductMigrationTest extends PostgresTestBase {
 
     @Autowired
     private DatabaseClient dbClient;
-
-    @BeforeAll
-    public static void startDb() {
-        database.start();
-    }
-
-    @AfterAll
-    public static void stopDb() {
-        database.stop();
-    }
-
-    @DynamicPropertySource
-    static void databaseProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", database::getJdbcUrl);
-        registry.add("spring.datasource.username", database::getUsername);
-        registry.add("spring.datasource.password", database::getPassword);
-    }
 
     @SuppressWarnings("ReactiveStreamsUnusedPublisher")
     @Test

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class ProductServiceApplicationTests {
+public class ProductServiceApplicationTests extends PostgresTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class RecommendationServiceApplicationTests {
+public class RecommendationServiceApplicationTests extends MongoDbTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
         "spring.flyway.enabled: false",
         "eureka.client.enabled=false"
 })
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;


### PR DESCRIPTION
Implement endpoint to retrieve all products with recommendations and reviews.

- Add GET /product-composite returning all products as ProductAggregate with recommendations, reviews, and service address.
- In ProductCompositeService, implement getAllProducts() using reactive style (Flux/Mono) and aggregate data from ProductService.getAllProducts(), RecommendationService.getRecommendations(productId), and ReviewService.getReviews(productId) with Mono.zip.
- In ProductService, implement getAllProducts() returning all products from the repository, including service address.
- In integration, call downstream services via WebClient; on errors, return empty lists for recommendations/reviews.
- Add end-to-end tests verifying all products, aggregated recommendations/reviews, and service address.