### PR TITLE
Product Service: validate entities before persisting

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "24",
   "build_system": "gradle",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "microservices:product-service:shop.microservices.core.product.ProductServiceApiTests#saveInvalidProduct",
+      "microservices:product-service:shop.microservices.core.product.ProductValidationTests#testReviewEntityValidationNegative"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/microservices/product-service/build.gradle
+++ b/microservices/product-service/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(':api')
     implementation project(':util')
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     implementation 'org.liquibase:liquibase-core'
     runtimeOnly 'org.postgresql:r2dbc-postgresql'

--- a/microservices/product-service/src/main/java/shop/microservices/core/product/persistence/ProductEntity.java
+++ b/microservices/product-service/src/main/java/shop/microservices/core/product/persistence/ProductEntity.java
@@ -1,5 +1,7 @@
 package shop.microservices.core.product.persistence;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
 import org.springframework.data.relational.core.mapping.Table;
@@ -13,10 +15,13 @@ public class ProductEntity {
     @Version
     private int version;
 
+    @Min(1)
     private int productId;
 
+    @Size(min = 5, max = 100)
     private String name;
 
+    @Min(1)
     private int weight;
 
     public ProductEntity() {

--- a/microservices/product-service/src/main/java/shop/microservices/core/product/services/ProductServiceImpl.java
+++ b/microservices/product-service/src/main/java/shop/microservices/core/product/services/ProductServiceImpl.java
@@ -1,5 +1,6 @@
 package shop.microservices.core.product.services;
 
+import jakarta.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,11 +23,17 @@ public class ProductServiceImpl implements ProductService {
 
     private final ProductMapper mapper;
 
+    private final Validator validator;
+
     @Autowired
-    public ProductServiceImpl(ProductRepository repository, ProductMapper mapper, ServiceUtil serviceUtil) {
+    public ProductServiceImpl(ProductRepository repository,
+                              ProductMapper mapper,
+                              ServiceUtil serviceUtil,
+                              Validator validator) {
         this.repository = repository;
         this.mapper = mapper;
         this.serviceUtil = serviceUtil;
+        this.validator = validator;
     }
 
     @Override
@@ -36,6 +43,11 @@ public class ProductServiceImpl implements ProductService {
         }
 
         ProductEntity entity = mapper.apiToEntity(body);
+
+        var constraints = validator.validate(entity);
+        if (!constraints.isEmpty()) {
+            throw new InvalidInputException(constraints.iterator().next().getMessage());
+        }
 
         return repository.save(entity)
                 .onErrorMap(

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductMigrationTest.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductMigrationTest.java
@@ -1,45 +1,15 @@
 package shop.microservices.core.product;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.r2dbc.core.DatabaseClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
 
 @SpringBootTest
-public class ProductMigrationTest {
-
-    private static final JdbcDatabaseContainer<?> database =
-            new PostgreSQLContainer<>("postgres:17.5")
-                    .withStartupTimeoutSeconds(300)
-                    .withDatabaseName("product-db")
-                    .withUsername("user")
-                    .withPassword("pwd");
+public class ProductMigrationTest extends PostgresTestBase {
 
     @Autowired
     private DatabaseClient dbClient;
-
-    @BeforeAll
-    public static void startDb() {
-        database.start();
-    }
-
-    @AfterAll
-    public static void stopDb() {
-        database.stop();
-    }
-
-    @DynamicPropertySource
-    static void databaseProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", database::getJdbcUrl);
-        registry.add("spring.datasource.username", database::getUsername);
-        registry.add("spring.datasource.password", database::getPassword);
-    }
 
     @SuppressWarnings("ReactiveStreamsUnusedPublisher")
     @Test

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApiTests.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApiTests.java
@@ -100,6 +100,14 @@ class ProductServiceApiTests extends PostgresTestBase {
                 .jsonPath("$.message").isEqualTo("Invalid productId: " + productIdInvalid);
     }
 
+    @Test
+    void saveInvalidProduct() {
+        Product product = new Product(1, "", 0, "SA");
+        Event<Integer, Product> event = new Event<>(CREATE, 0, product);
+
+        assertThrows(InvalidInputException.class, () -> messageProcessor.accept(event));
+    }
+
     private WebTestClient.BodyContentSpec getAndVerifyProduct(int productId, HttpStatus expectedStatus) {
         return getAndVerifyProduct("/" + productId, expectedStatus);
     }

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class ProductServiceApplicationTests {
+public class ProductServiceApplicationTests extends PostgresTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/product-service/src/test/java/shop/microservices/core/product/ProductValidationTests.java
+++ b/microservices/product-service/src/test/java/shop/microservices/core/product/ProductValidationTests.java
@@ -1,0 +1,46 @@
+package shop.microservices.core.product;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+import shop.microservices.core.product.persistence.ProductEntity;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProductValidationTests {
+
+    @Test
+    public void testReviewEntityValidationNegative() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = validatorFactory.getValidator();
+
+            var violations = validator.validate(
+                    new ProductEntity(-1, "", 0));
+
+            assertFalse(violations.isEmpty());
+            assertEquals(3, violations.size());
+            assertThat(violations)
+                    .extracting(it -> it.getPropertyPath() + " " + it.getMessage())
+                    .containsExactlyInAnyOrder(
+                            "name size must be between 5 and 100",
+                            "weight must be greater than or equal to 1",
+                            "productId must be greater than or equal to 1");
+        }
+    }
+
+    @Test
+    public void testReviewEntityValidationPositive() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = validatorFactory.getValidator();
+
+            var violations = validator.validate(
+                    new ProductEntity(
+                            1,
+                            "Water",
+                            4));
+
+            assertTrue(violations.isEmpty());
+        }
+    }
+}

--- a/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
+++ b/microservices/recommendation-service/src/test/java/shop/microservices/core/recommendation/RecommendationServiceApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.core.env.Environment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-public class RecommendationServiceApplicationTests {
+public class RecommendationServiceApplicationTests extends MongoDbTestBase {
 
     @Autowired
     private Environment environment;

--- a/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
+++ b/microservices/review-service/src/test/java/shop/microservices/core/review/ReviewServiceApplicationTests.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
         "spring.flyway.enabled: false",
         "eureka.client.enabled=false"
 })
-public class ReviewServiceApplicationTests {
+public class ReviewServiceApplicationTests extends MySqlTestBase {
 
     @Autowired
     private Environment environment;


### PR DESCRIPTION
- Introduce constraints for the 'productId,' 'name,' and 'weight' fields
- Update 'ProductServiceImpl' to validate Product entity during save
- Add test cases to verify validation logic in 'ProductValidationTests'
- Enhance API tests to cover invalid Product save scenarios